### PR TITLE
Fix table material opacity and emissive color

### DIFF
--- a/src/game-elements/game-objects.ts
+++ b/src/game-elements/game-objects.ts
@@ -145,11 +145,14 @@ export class GameObjects {
 
     // LCD Screen Effect: Make the texture emissive so it glows like a screen
     groundMat.emissiveTexture = groundMat.diffuseTexture
-    // Use Moderate Blue-Grey to simulate a lit LCD screen (black pixels are never truly black)
-    groundMat.emissiveColor = Color3.FromHexString("#222233")
+    // FIX: Set to Black to prevent "milky/washed out" look
+    groundMat.emissiveColor = Color3.Black()
 
     // Remove external light influence (Diffuse) to prevent washout
     groundMat.diffuseColor = Color3.Black()
+
+    // FIX: Reduce alpha to prevent "solid plastic" look, simulating dark glass
+    groundMat.alpha = 0.85
 
     // Remove specular highlights to avoid "plastic" glare
     groundMat.specularColor = Color3.Black()

--- a/src/shaders/scanline.ts
+++ b/src/shaders/scanline.ts
@@ -12,7 +12,7 @@ export const scanlinePixelShader = {
         // 1. Scanlines
         // A high frequency sine wave along the Y axis
         float scanlineCount = 800.0;
-        float scanlineIntensity = 0.15;
+        float scanlineIntensity = 0.25;
 
         // Use sine wave to create alternating light/dark bands
         // Range [-1, 1] -> [0.85, 1.0] for multiplicative
@@ -25,9 +25,6 @@ export const scanlinePixelShader = {
         // Darken the corners to simulate a CRT/curved screen
         float dist = distance(vUV, vec2(0.5, 0.5));
         float vignette = 1.0 - smoothstep(0.4, 0.9, dist);
-
-        // Boost brightness slightly to compensate for scanline darkening
-        color *= 1.2;
 
         color *= vignette;
 


### PR DESCRIPTION
- Set `groundMat.emissiveColor` to Black to prevent washed-out look
- Set `groundMat.alpha` to 0.85 to simulate dark glass and fix "too opaque" issue
- Maintained `diffuseColor` and `specularColor` as Black for screen-like aesthetic