### PR TITLE
feat: Add Solar Flare Adventure Track

### DIFF
--- a/src/game.ts
+++ b/src/game.ts
@@ -825,6 +825,8 @@ export class Game {
       } else if (track === AdventureTrackType.DIGITAL_ZEN_GARDEN) {
           this.nextAdventureTrack = AdventureTrackType.SYNTHWAVE_SURF;
       } else if (track === AdventureTrackType.SYNTHWAVE_SURF) {
+          this.nextAdventureTrack = AdventureTrackType.SOLAR_FLARE;
+      } else if (track === AdventureTrackType.SOLAR_FLARE) {
           this.nextAdventureTrack = AdventureTrackType.NEON_HELIX;
       } else {
           this.nextAdventureTrack = AdventureTrackType.NEON_HELIX;


### PR DESCRIPTION
Implemented the 'Solar Flare' adventure track as specified in PLAN.md Section 28. This includes:
1.  **Geometry & Physics**: Created the track layout using `MeshBuilder` and Rapier physics, including a launch ramp, parabolic arch, gravity well field, and curved "solar wind" section.
2.  **Gravity Well System**: Added a new `GravityWell` interface and update logic in `AdventureMode` to support radial attraction forces.
3.  **Game Logic**: Integrated the new track into the `AdventureTrackType` enum and the level rotation sequence in `Game.ts`.
4.  **Visuals**: Used Orange-Red and Yellow materials to match the solar theme.
Verified via compilation (`npm run build`).

---
*PR created automatically by Jules for task [15908942370640846478](https://jules.google.com/task/15908942370640846478) started by @ford442*