### PR TITLE
Add 'The Casino Heist' Adventure Track

### DIFF
--- a/src/game.ts
+++ b/src/game.ts
@@ -911,6 +911,8 @@ export class Game {
       } else if (track === AdventureTrackType.NEURAL_NETWORK) {
           this.nextAdventureTrack = AdventureTrackType.NEON_STRONGHOLD;
       } else if (track === AdventureTrackType.NEON_STRONGHOLD) {
+          this.nextAdventureTrack = AdventureTrackType.CASINO_HEIST;
+      } else if (track === AdventureTrackType.CASINO_HEIST) {
           this.nextAdventureTrack = AdventureTrackType.NEON_HELIX;
       } else {
           this.nextAdventureTrack = AdventureTrackType.NEON_HELIX;


### PR DESCRIPTION
Implemented the 'The Casino Heist' adventure track as per PLAN.md. This includes:
- A new `createCasinoHeistTrack` method in `AdventureMode` class.
- Materials for Felt (Red), Gold, and Poker Chips.
- A rotating Roulette Wheel with sensor pockets that reset the ball.
- Kinematic 'Slot Gates' that move up and down.
- Static 'Chip Stack' obstacles with high restitution.
- Integration into the adventure track cycle in `Game.ts`.

---
*PR created automatically by Jules for task [4623884975418133150](https://jules.google.com/task/4623884975418133150) started by @ford442*