### PR TITLE
plan: weekly_plan.md — 2026-04-17 (Gold Balls polish, User Idea mode)

### DIFF
--- a/weekly_plan.md
+++ b/weekly_plan.md
@@ -1,234 +1,59 @@
-# Weekly Development Plan: Gold Pachinko Balls Feature
+# Pachinball — Weekly Plan
 
-## Overview
-This week we're introducing **Gold Pachinko Balls** as special collectible items within the machine. These premium balls will add visual richness and create distinct gameplay moments as players collect and stack them.
+## Today's focus
+**2026-04-17 — Finish & polish Gold Pachinko Balls integration (User Idea mode).**
+The feature is partially implemented (BallType enum, BALL_TIERS config, BallManager spawn/collect, BallStackVisual, UI counter, onGoldBallCollected hook wired in game.ts at L1181). Remaining: verify PBR material quality across quality tiers for both gold variants, confirm SOLID_GOLD collection triggers a meaningfully distinct cabinet reaction (not just the generic `startJackpotSequence()`), validate the BallStackVisual feedback actually reads as "accumulating progress" in-game, and close any integration gaps where scoring/state don't reflect collection. Tighten before adding more surface area.
+
+## Ideas
+- [in progress — 2026-04-17] Gold Pachinko Balls feature — Gold-Plated (common, ~20%, +1000/×2) and Solid Gold (rare, ~5%, +5000/×5) variants with PBR material differentiation, stacking/counting visual, scoring integration, and cabinet reaction effects. Spec below in "Feature spec — Gold Pachinko Balls".
+- [ ] Dedicated `onSolidGoldCollected` cabinet reaction distinct from `startJackpotSequence()` (per-event pulse vs. mode).
+- [ ] Quality-tier-aware material variants: verify iridescence/clear-coat only engage on HIGH tier, gold still reads as gold on LOW.
+
+## Backlog
+- [ ] Formal game state machine + event bus (carried from PLAN.md / GPT architectural notes — IDLE/PLAYING/MODE/GAME_OVER transitions, event-driven subscribers for display/effects/audio).
+- [ ] Gameplay tuning/config extraction — migrate remaining magic numbers (bumper force, flipper impulse, scoring thresholds) into `config.ts`.
+- [ ] Backbox display system — layered video/image/shader/reels with per-state overrides (per PROJECT CONTEXT active focus).
+- [ ] Debug HUD overlay — state, physics step, active balls, scores, multipliers, mode timers.
+- [ ] Unit test coverage for BallManager type assignment, scoring, and drain lifecycle.
+- [ ] Numerous audit reports in repo root (PHYSICS_*, LIGHTING_*, MATERIAL_*, INPUT_*, CAMERA_*) — triage which still reflect current code vs. stale.
+
+## Done
+- 2026-04-17: Moved Gold Pachinko Balls scaffolding into the Done-adjacent "in progress" slot after discovering it's substantially built in `src/config.ts` (BallType/BALL_TIERS), `src/game-elements/ball-manager.ts` (spawn/collect/callback, L42–L806), `src/game-elements/ball-stack-visual.ts`, `src/materials/material-ball.ts`, and `src/game.ts` (L1181 onGoldBallCollected wiring). Polish/verify phase, not build phase.
+- 2026-03-21 (PR #115/#114): TypeScript error cleanup across adventure-mode, ball-manager, mag-spin-feeder, nano-loom-feeder, prism-core-feeder.
+- 2026-03-20 (PR #110): Lighting/shadow/post-processing audit improvements — SSAO2, FXAA, ACES, bloom tune, DoF, atmosphere state system.
+- 2026-03-19 (PR #109): Hardware-adaptive quality tiers, advanced PBR (anisotropy/sheen/iridescence/clear-coat), bumper state system.
+- 2026-02-25 (PR #106): Adventure track switching + dual-screen display integration.
+
+## Last run
+Date: 2026-04-17
+Mode: User Idea
+Focus: Finish & polish Gold Pachinko Balls integration
+Outcome: _to be filled end of day_
 
 ---
 
-## Feature: Gold Pachinko Balls
+## Feature spec — Gold Pachinko Balls
+
+(Preserved from the original weekly_plan.md; source of today's User Idea.)
 
 ### Visual Variants
 
-#### Gold-Plated Balls
-- **Appearance:** Lighter, more reflective surface with subtle highlights
-- **Material Properties:** 
-  - High metallic factor
-  - Lower roughness for polished look
-  - Subtle specular highlights
-  - Slight yellow/warm tone overlay
-- **Purpose:** Common premium variant, earns standard bonus points
+**Gold-Plated Balls** — lighter, more reflective; high metallic, lower roughness, subtle yellow/warm tone. Common premium variant, standard bonus points.
 
-#### Solid Gold Balls
-- **Appearance:** Deeper, richer gold color with premium material definition
-- **Material Properties:**
-  - Rich yellow-gold base color
-  - Higher metallic saturation
-  - Controlled roughness for realistic precious metal appearance
-  - Strong reflectivity with warm light response
-- **Purpose:** Rare jackpot variant, high-value scoring moment
+**Solid Gold Balls** — deeper richer gold; rich yellow-gold albedo, higher metallic saturation, controlled roughness, strong warm reflectivity. Rare jackpot variant, high-value scoring moment.
 
-### Visual Implementation
-- **PBR Materials:** Leverage existing PBR system (see MATERIAL_PBR_AUDIT_REPORT.md)
-- **Material Definitions:**
-  - Create separate metallic material slots for each variant
-  - Define albedo, normal maps, roughness, and metallic parameters
-  - Ensure proper light interaction under varying cabinet lighting conditions
-- **Visual Distinction:** Both variants must be instantly recognizable to players during gameplay
+### Implementation anchors (already in code)
+- `src/config.ts` — `BallType` enum + `BALL_TIERS` (spawn rate, bonus points, multiplier).
+- `src/materials/material-ball.ts` — PBR variants (verify per quality tier).
+- `src/game-elements/ball-manager.ts` — `createBallOfType`, `getMaterialForType`, `collectBall`, `onGoldBallCollected` callback, `goldBallCount`.
+- `src/game-elements/ball-stack-visual.ts` — accumulation visual.
+- `src/game/game-ui.ts` — gold ball counter HUD element.
+- `src/game.ts` L1181 — wires `setOnGoldBallCollected`.
+- `src/effects/effects-core.ts` L602 — `startJackpotSequence` currently reused for gold events.
 
-### Ball Stacking & Counting Mechanics
-- Balls accumulate as they're collected, simulating traditional pachinko ball counting
-- Stacking creates visual feedback for player progress
-- Rare solid gold balls create memorable collection moments with special effects
-
-### Integration Points
-- **Scoring System:** Gold ball collection triggers bonus points
-- **Game State:** Ball collection tracked and displayed
-- **Visual Feedback:** Balls reflect cabinet lighting for immersive gameplay
-- **Cabinet Reactions:** Lighting and effects sync with gold ball collection events
-
----
-
-## Technical References
-- MATERIAL_PBR_AUDIT_REPORT.md - PBR material system
-- PLAN.md - Overall game architecture
-- PHYSICS_AUDIT_MASTER.md - Ball physics integration
-
-from Gemini 3.1 pro:
-1. Gameplay Enhancements (The "Gold Ball" Feature)
-Your weekly plan clearly outlines the introduction of premium collectible items that affect scoring and visual feedback.
-
-Introduce Ball Tiers: You need to implement the two distinct visual variants: the "Gold-Plated" ball (a common premium variant for standard bonus points) and the rare "Solid Gold" ball (a jackpot variant for high-value scoring moments).
-
-Implement Stacking/Counting: Instead of balls just disappearing when they drain, you need a visual representation of them accumulating. This stacking simulates traditional pachinko ball counting and gives players immediate visual feedback on their progress.
-
-Tie Collection to Cabinet Reactions: When a player collects a rare solid gold ball, it should trigger special lighting effects and cabinet reactions to create a memorable gameplay moment.
-
-2. Codewise Implementation Steps
-To make the gameplay features above a reality, you will need to modify several core systems currently imported and initialized within src/game.ts:
-
-Update MaterialLibrary (Visuals): You will need to define separate metallic PBR material slots for the new variants. For the Gold-Plated balls, set a high metallic factor with lower roughness and a subtle yellow tint; for Solid Gold, use a deeper yellow-gold albedo, higher metallic saturation, and strong reflectivity.
-
-Modify BallManager: Currently, BallManager handles standard balls and skins. You must extend this class to assign types/tags to balls upon spawning (e.g., standard, gold-plated, solid-gold) and apply the correct PBR materials from the MaterialLibrary.
-
-Update Collision and Scoring Logic: Inside src/game.ts, locate the processCollision method and the handleBallLoss method (where balls currently drain). You will need to check the "type" of the ball when it drains. If it is a gold variant, add it to a new goldBallCount variable in your game state, trigger the bonus score addition, and execute the physical stacking animation.
-
-Integrate with EffectsSystem: When a solid gold ball is collected, call methods on your EffectsSystem (which already handles things like startJackpotSequence() and setAtmosphereState()) to sync the cabinet lighting and visual flair with the gold ball collection event.
-
-By extending your BallManager and MaterialLibrary to support these new ball types, and updating your scoring handlers in game.ts to recognize them, you will seamlessly connect your physics engine with your new progression loops.
-
-
-from gpt 5.4:
-Copilot said: Here are the most obvious next steps
-Here are the most obvious next steps to improve Pachinball both codewise and as a game, based on the repo context you shared.
-
-Codewise next steps
-Strengthen module boundaries
-
-Keep game.ts thin and use the src/game-elements/ split consistently.
-Verify each responsibility lives in the right file:
-game-objects.ts for flippers, bumpers, walls, pins
-ball-manager.ts for spawning/resetting/catching balls
-display.ts for reels, score, LED/backbox
-effects.ts for particles, bloom, audio triggers
-physics.ts for Rapier init/step/collision wiring
-adventure-mode.ts for Holo-deck mode
-Add a clearer game state flow
-
-Formalize transitions between IDLE, PLAYING, mode-specific states, and game-over/game-reset.
-Make state changes event-driven so features like multiball, jackpots, or adventure mode can hook in cleanly.
-Improve physics/gameplay separation
-
-Keep all Rapier configuration in physics.ts.
-Make ball and object managers consume physics services rather than configure physics themselves.
-This will make tuning easier and prevent accidental coupling.
-Create a unified event system
-
-Emit game events like:
-ball drained
-bumper hit
-jackpot reached
-mode started/ended
-multiball started
-Let display/effects/audio subscribe to those events instead of calling each other directly.
-Add tuning/config data
-
-Move gameplay constants into config objects or JSON/TS config modules.
-Examples:
-bumper force
-flipper impulse
-ball spawn count
-scoring thresholds
-fever mode timing
-This will make balancing much faster.
-Harden async initialization
-
-Ensure assets, Babylon meshes, and Rapier init all resolve before gameplay starts.
-Add a loading phase that cleanly gates input and scene setup.
-Add tests for core logic
-
-Especially for:
-state transitions
-scoring rules
-mode triggers
-ball lifecycle
-Even a small suite will help as the game gets more complex.
-Add diagnostics/debug tools
-
-On-screen debug overlay for:
-current game state
-physics step info
-active balls
-scores/multipliers
-mode timers
-This will make balancing and bug hunting much easier.
-Game design next steps
-Make the core loop more explicit
-
-Right now the biggest opportunity is to clarify the “why” of play:
-What is the main objective?
-How does the player progress?
-What unlocks the adventure mode?
-Give the player a visible short-term and long-term goal.
-Add progression and rewards
-
-Examples:
-multipliers
-combo chains
-mode unlocks
-meta-progress between runs
-achievement-style bonuses
-This gives the game more staying power than just “hit things and score.”
-Differentiate zones
-
-Create distinct table regions with unique behavior:
-pin field
-flipper zone
-bonus lanes
-adventure/Holo-deck zone
-jackpot path
-Each zone should feel meaningfully different.
-Deepen the slot-machine/backbox layer
-
-The backbox can become a real meta-system:
-award multipliers
-trigger temporary rules
-spawn special balls
-activate fever mode
-influence table behavior
-This is a great place to make the hybrid identity feel unique.
-Add more signature events
-
-Big arcade games are built around memorable moments:
-jackpot
-multiball chaos
-fever mode
-mini-boss/adventure sequence
-table-wide light shows
-Make each one visually and sonically obvious.
-Improve feedback
-
-Use stronger feedback for:
-hits
-combos
-mode activation
-near misses
-jackpots
-Better feedback makes the game feel much more polished even without huge content changes.
-Balance risk vs reward
-
-Pachinko-style randomness can be fun, but players need some agency.
-Ensure flippers, bumps, and skill shots can consistently influence outcomes.
-Make lucky outcomes possible, but skillful play rewarding.
-Expand adventure mode
-
-Since adventure-mode.ts already exists as a distinct concept, it’s a natural place to build a second gameplay layer:
-mission objectives
-temporary rule changes
-special targets
-themed encounters
-This could become the standout feature of the whole game.
-Highest-value immediate priorities
-If you want the best return on effort, I’d prioritize these first:
-
-Event system
-State flow cleanup
-Gameplay tuning/config extraction
-Backbox/reward progression
-Adventure mode expansion
-Debug overlay + tests
-Suggested roadmap
-Short term
-Clean up state handling
-Add event bus / signal system
-Extract gameplay constants
-Add debug HUD
-Mid term
-Improve scoring/multiplier systems
-Add more distinct table zones
-Strengthen backbox/slot-machine rewards
-Polish audio/visual feedback
-Long term
-Expand adventure mode into a full secondary loop
-Add missions, unlocks, and meta-progression
-Add more table layouts, modes, or themes
-
+### Remaining integration points to verify/finish
+1. **PBR quality across tiers** — LOW tier still reads as gold; HIGH tier engages iridescence/clear-coat where defined.
+2. **Cabinet reaction differentiation** — SOLID_GOLD deserves a distinct event, not a reused mode trigger.
+3. **Stacking feedback** — BallStackVisual reads as "progress accumulating," not just clutter.
+4. **Scoring integration** — ensure bonus points land in the same scoring path as normal hits, not a side channel.
+5. **Game-state reactivity** — gold counter persists across lives/game-over appropriately.


### PR DESCRIPTION
## Summary

Weekly planner output for Pachinball, 2026-04-17. Restructures `weekly_plan.md` into the standard **Today's focus / Ideas / Backlog / Done / Last run** layout and selects today's focus under **User Idea mode**.

## Mode

**User Idea mode.** The existing `weekly_plan.md` was entirely the Gold Pachinko Balls spec — user-written ideas beat generated ones per the planner's priority cascade.

## Key discovery

Gold Pachinko Balls is **not greenfield** — it's substantially built and needs integration/polish:

- `src/config.ts` — `BallType` enum + `BALL_TIERS` (spawn rates 75/20/5, bonus points 0/1000/5000, multipliers 1×/2×/5×)
- `src/game-elements/ball-manager.ts` — `createBallOfType`, `getMaterialForType`, `collectBall`, `goldBallCount`, `onGoldBallCollected` callback
- `src/game-elements/ball-stack-visual.ts` — accumulation visual
- `src/materials/material-ball.ts` — PBR variants
- `src/game/game-ui.ts` — gold ball counter HUD
- `src/game.ts` L1181 — `setOnGoldBallCollected` wired
- `src/effects/effects-core.ts` L602 — `startJackpotSequence` currently reused for gold events

Today's focus: verify PBR quality across tiers, differentiate the SOLID_GOLD cabinet reaction from the reused jackpot sequence, validate stacking/scoring end-to-end.

## Changes

- Rewrote `weekly_plan.md` with: Today's focus, Ideas (Gold Balls `[in progress — 2026-04-17]`), Backlog, Done, Last run.
- Preserved original Gold Balls spec as a "Feature spec" appendix.

## Test plan

- [ ] Noah reviews today's focus framing and confirms it matches his understanding.
- [ ] Adjust before kimi-cli runs if PBR tier behavior or SOLID_GOLD reaction differ from planner's reading.

https://claude.ai/code/session_0142H7TDo1jqjai6unVJdHnz