### PR TITLE
plan: weekly plan 2026-04-23 — Display state sync (New Idea mode)

### DIFF
--- a/weekly_plan.md
+++ b/weekly_plan.md
@@ -1,40 +1,40 @@
 # Pachinball — Weekly Plan
 
 ## Today's focus
-**2026-04-17 — Finish & polish Gold Pachinko Balls integration (User Idea mode). ✅ DONE**
-Polished and closed all remaining integration gaps: quality-tier-aware PBR materials, distinct solid-gold cabinet pulse, horizontal arc stack visual with threshold feedback, visible scoring popups, and per-game/session gold-ball state management.
+**2026-04-23 — Backbox Display System: Game↔Display State Sync & FEVER Layer (New Idea mode)**
+Wire `GameStateManager` transitions to automatically drive `DisplaySystem.setDisplayState()`, trigger the currently-silent `DisplayState.FEVER` from its correct game event, and verify all 4 display layers (video/image/shader/reels) respond correctly to every state. The scaffold is complete; the binding is the gap.
 
 ## Ideas
-- [x] Gold Pachinko Balls feature — Gold-Plated (common, ~20%, +1000/×2) and Solid Gold (rare, ~5%, +5000/×5) variants with PBR material differentiation, stacking/counting visual, scoring integration, and cabinet reaction effects. Spec below in "Feature spec — Gold Pachinko Balls".
-- [x] Dedicated `onSolidGoldCollected` cabinet reaction distinct from `startJackpotSequence()` (per-event pulse vs. mode).
-- [x] Quality-tier-aware material variants: verify iridescence/clear-coat only engage on HIGH tier, gold still reads as gold on LOW.
+- [in progress — 2026-04-23] Backbox display state synchronization — `GameStateManager` state transitions don't auto-drive `DisplaySystem`; `DisplayState.FEVER` is configured but never triggered in `game.ts`. Wire the two systems, close the FEVER gap, verify per-state layer overrides end-to-end.
+- [ ] Event bus architecture — Replace the callback map in `GameStateManager` and scattered direct calls in `game.ts` with a lightweight typed event bus. Decouples display/effects/audio/scoring from the central game loop before the next feature layer.
+- [ ] BallManager unit tests + config extraction — Add Vitest for pure-TS unit tests of BallManager type assignment, scoring bonuses, and drain lifecycle. Simultaneously extract remaining magic numbers from `game.ts` into `config.ts`.
 
 ## Backlog
-- [ ] Formal game state machine + event bus (carried from PLAN.md / GPT architectural notes — IDLE/PLAYING/MODE/GAME_OVER transitions, event-driven subscribers for display/effects/audio).
+- [ ] Formal game state machine + event bus — `GameStateManager` in `src/game/game-state.ts` exists with callbacks but no event bus. Effects field is commented out as UNUSED. Full subscriber-based wiring deferred.
 - [ ] Gameplay tuning/config extraction — migrate remaining magic numbers (bumper force, flipper impulse, scoring thresholds) into `config.ts`.
-- [ ] Backbox display system — layered video/image/shader/reels with per-state overrides (per PROJECT CONTEXT active focus).
-- [ ] Debug HUD overlay — state, physics step, active balls, scores, multipliers, mode timers.
-- [ ] Unit test coverage for BallManager type assignment, scoring, and drain lifecycle.
-- [ ] Numerous audit reports in repo root (PHYSICS_*, LIGHTING_*, MATERIAL_*, INPUT_*, CAMERA_*) — triage which still reflect current code vs. stale.
+- [ ] Backbox display system — scaffold complete (~1292 lines, 7 files in `src/display/`); ADVENTURE/IDLE/JACKPOT/REACH manually wired in `game.ts` (8 call sites); FEVER dark; `GameStateManager`↔`DisplaySystem` auto-sync missing. **Active today.**
+- [ ] Unit test coverage for BallManager type assignment, scoring, and drain lifecycle. No Vitest installed; only Playwright smoke test (`tests/verify_prism_core.spec.ts`) exists.
+- [ ] Audit reports in repo root (PHYSICS_*, LIGHTING_*, MATERIAL_*, INPUT_*, CAMERA_*) — triage which still reflect current code vs. stale.
 
 ## Done
+- 2026-04-23: **Debug HUD overlay** marked done (PR #118 merged 2026-04-17). Re-enabled and modernized: snapshot boundary, throttled updates, developer settings toggle. Files: `src/game-elements/debug-hud.ts`, `src/game.ts`, `index.html`.
 - 2026-04-17: **Gold Pachinko Balls polish complete.**
-  - `src/materials/material-ball.ts` — clear coat and iridescence now gated by `QualityTier.HIGH`; LOW tier retains strong albedo/metallic so gold still reads as gold.
-  - `src/effects/effects-core.ts` — added `startSolidGoldPulse()` (~1.5 s bloom + gold→magenta cabinet lighting + chime + vignette), respecting `reducedMotion`.
-  - `src/game.ts` — solid-gold drains now trigger `startSolidGoldPulse()` instead of the full 10-second jackpot sequence; added floating `+points` messages; `startGame()` resets `goldBallStack` and `ballStackVisual`; added `sessionGoldBalls` counter/badge.
-  - `src/game-elements/ball-stack-visual.ts` — redesigned as a horizontal arc meter with threshold pop-in flash near jackpot (8+ balls) and solid-gold sorting to the front.
-  - Type-check (`npx tsc -b`) and Playwright smoke test both pass.
-- 2026-04-17: Moved Gold Pachinko Balls scaffolding into the Done-adjacent "in progress" slot after discovering it's substantially built in `src/config.ts` (BallType/BALL_TIERS), `src/game-elements/ball-manager.ts` (spawn/collect/callback, L42–L806), `src/game-elements/ball-stack-visual.ts`, `src/materials/material-ball.ts`, and `src/game.ts` (L1181 onGoldBallCollected wiring). Polish/verify phase, not build phase.
+  - `src/materials/material-ball.ts` — clear coat and iridescence gated by `QualityTier.HIGH`; LOW tier retains gold read.
+  - `src/effects/effects-core.ts` — `startSolidGoldPulse()` (~1.5 s bloom + gold→magenta cabinet lighting + chime + vignette), respecting `reducedMotion`.
+  - `src/game.ts` — solid-gold drains trigger `startSolidGoldPulse()`; floating `+points` messages; `startGame()` resets `goldBallStack` / `ballStackVisual`; `sessionGoldBalls` counter/badge.
+  - `src/game-elements/ball-stack-visual.ts` — horizontal arc meter with threshold pop-in flash (8+ balls), solid-gold sorting to front.
+  - Type-check (`npx tsc -b`) and Playwright smoke test pass.
+- 2026-04-17: Moved Gold Pachinko Balls scaffolding into Done after discovering it's substantially built in `src/config.ts`, `src/game-elements/ball-manager.ts`, `src/game-elements/ball-stack-visual.ts`, `src/materials/material-ball.ts`, and `src/game.ts` L1181.
 - 2026-03-21 (PR #115/#114): TypeScript error cleanup across adventure-mode, ball-manager, mag-spin-feeder, nano-loom-feeder, prism-core-feeder.
 - 2026-03-20 (PR #110): Lighting/shadow/post-processing audit improvements — SSAO2, FXAA, ACES, bloom tune, DoF, atmosphere state system.
 - 2026-03-19 (PR #109): Hardware-adaptive quality tiers, advanced PBR (anisotropy/sheen/iridescence/clear-coat), bumper state system.
 - 2026-02-25 (PR #106): Adventure track switching + dual-screen display integration.
 
 ## Last run
-Date: 2026-04-17
-Mode: User Idea
-Focus: Finish & polish Gold Pachinko Balls integration
-Outcome: Complete. All 5 integration points verified/closed. Type-check clean. Playwright smoke test passing.
+Date: 2026-04-23
+Mode: New Idea
+Focus: Backbox Display System — Game↔Display state sync, FEVER layer completion
+Outcome: (fill in at end of day)
 
 ---
 


### PR DESCRIPTION
## Summary

- Moves Debug HUD overlay (PR #118) to Done in `weekly_plan.md`
- Adds two new Ideas: event bus architecture, BallManager unit tests + config extraction
- Sets today's focus: Backbox Display System — Game↔Display state sync + FEVER layer completion

## Weekly plan changes
- **Done**: Debug HUD overlay (PR #118, merged 2026-04-17)
- **Ideas**: Added event bus and BallManager test ideas for future runs
- **Backlog**: Updated display system status note (scaffold complete, FEVER dark, sync missing)
- **Today's focus**: Wire `GameStateManager` → `DisplaySystem.setDisplayState()` auto-sync; trigger `DisplayState.FEVER`

https://claude.ai/code/session_01E9CPhpmEMnAdRCHoA5Dzvi

---
_Generated by [Claude Code](https://claude.ai/code/session_01E9CPhpmEMnAdRCHoA5Dzvi)_