### PR TITLE
Fix lint errors and tighten Playwright test discovery

### DIFF
--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -2,6 +2,7 @@ import { defineConfig, devices } from '@playwright/test';
 
 export default defineConfig({
   testDir: '.',
+  testMatch: '**/*.spec.ts',
   use: {
     baseURL: 'http://localhost:5173',
   },

--- a/src/game-elements/map-system.ts
+++ b/src/game-elements/map-system.ts
@@ -27,6 +27,7 @@ export class MapSystem {
   private loaded = false
   private loadPromise: Promise<void> | null = null
 
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
   constructor(_apiBase?: string) {
     // apiBase parameter kept for API compatibility but we use API_BASE from config
 

--- a/src/game-elements/path-mechanics.ts
+++ b/src/game-elements/path-mechanics.ts
@@ -227,6 +227,7 @@ export class MovingGate extends PathMechanic {
     )
   }
 
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
   update(dt: number, _ballBodies: RAPIER.RigidBody[]): void {
     if (!this.isSpawned || !this.physicsBody) return
 
@@ -934,7 +935,7 @@ export class ReactivePegCluster extends PathMechanic {
           }
           break
 
-        case PegState.ACTIVE:
+        case PegState.ACTIVE: {
           // Glowing, pulsing
           const pulse = 2 + Math.sin(this.pulseTime * 2 + i) * 0.5
           light.intensity = pulse
@@ -944,6 +945,7 @@ export class ReactivePegCluster extends PathMechanic {
           const targetScale = 1 + this.pegHits[i] * 0.1
           peg.scaling.y = Scalar.Lerp(peg.scaling.y, targetScale, dt * 10)
           break
+        }
       }
     }
   }

--- a/src/materials/index.ts
+++ b/src/materials/index.ts
@@ -56,7 +56,7 @@ export class MaterialLibrary extends MaterialLibraryBase {
   }
 
   /** Override quality tier setter to sync across all modules */
-  override set qualityTier(tier: QualityTier | any) {
+  override set qualityTier(tier: QualityTier) {
     this._qualityTier = tier
     this.syncQualityTier()
   }


### PR DESCRIPTION
## Summary

- Suppress `no-unused-vars` on intentionally unused interface params (`_apiBase`, `_ballBodies`) via inline eslint-disable comments
- Wrap `case PegState.ACTIVE` block in braces to fix `no-case-declarations` errors
- Remove `| any` from `qualityTier` setter in `MaterialLibrary` — accepts `QualityTier` only
- Add `testMatch: '**/*.spec.ts'` to `playwright.config.ts` so Vitest `.test.ts` files are not incorrectly picked up by Playwright

## Test plan

- [ ] `npm run build` — exits 0
- [ ] `npm run lint` — exits 0 (0 errors, 1 pre-existing warning)
- [ ] `npx playwright test` — blocked pending `#debug-hud` toggle fix (see pipeline report)
- [ ] `python deploy.py` — pending Playwright pass
- [ ] Verify `https://test.1ink.us/pachinball/index.html` returns HTTP 200

https://claude.ai/code/session_01Q1jfg5quk5RgnsidbNNZrx

---
_Generated by [Claude Code](https://claude.ai/code/session_01Q1jfg5quk5RgnsidbNNZrx)_