### PR TITLE
fix: move CRT shader texture samples before non-uniform branch for We…

### DIFF
--- a/src/shaders/crt-effect.ts
+++ b/src/shaders/crt-effect.ts
@@ -95,18 +95,21 @@ export const crtEffectShader = {
     
     void main(void) {
       vec2 curvedUV = applyCurvature(vUV, uCurvature);
-      
+
+      // Sample before any non-uniform branch: WGSL (WebGPU) requires textureSample to be
+      // called in uniform control flow. The bounds-check below contains a per-fragment early
+      // return, which would make all subsequent textureSample calls non-uniform. Sampling
+      // first is safe — out-of-bounds fragments discard the result immediately after.
+      float r = texture2D(textureSampler, curvedUV + vec2(uChromaticAberration * 0.01, 0.0)).r;
+      float g = texture2D(textureSampler, curvedUV).g;
+      float b = texture2D(textureSampler, curvedUV - vec2(uChromaticAberration * 0.01, 0.0)).b;
+      vec3 color = vec3(r, g, b);
+
       // Discard if outside screen bounds (for curvature)
       if (curvedUV.x < 0.0 || curvedUV.x > 1.0 || curvedUV.y < 0.0 || curvedUV.y > 1.0) {
         gl_FragColor = vec4(0.0, 0.0, 0.0, 1.0);
         return;
       }
-      
-      // Chromatic aberration (RGB shift)
-      float r = texture2D(textureSampler, curvedUV + vec2(uChromaticAberration * 0.01, 0.0)).r;
-      float g = texture2D(textureSampler, curvedUV).g;
-      float b = texture2D(textureSampler, curvedUV - vec2(uChromaticAberration * 0.01, 0.0)).b;
-      vec3 color = vec3(r, g, b);
       
       // Modern bloom/glow for bright elements
       if (uGlow > 0.0) {


### PR DESCRIPTION
…bGPU

WGSL (WebGPU) requires textureSample to be called from uniform control flow. The bounds-check early return at the top of main() created a non-uniform divergence point; the three texture2D calls for chromatic aberration followed it, triggering GPUValidationError on every frame and invalidating the entire render pipeline.

Fix: reorder so all texture2D calls happen before the bounds-check if. Out-of-bounds fragments sample and immediately discard — negligible cost.

https://claude.ai/code/session_019pCVRHvC7ouPa5KrrhAFVG

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized CRT effect shader rendering by improving the sequencing of texture sampling and boundary detection operations for better performance.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ford442/pachinball/pull/139)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->