### PR TITLE
fix: eliminate ResizeObserver feedback loop causing startup hang

### DIFF
--- a/src/game/game-renderer.ts
+++ b/src/game/game-renderer.ts
@@ -82,6 +82,8 @@ export class GameRenderer {
   private _resizeObserver: ResizeObserver | null = null
   private _sceneOptimizer: SceneOptimizer | null = null
   private _scanlinePostProcess: PostProcess | null = null
+  private _lastResizeWidth = 0
+  private _lastResizeHeight = 0
 
   constructor(host: RendererHost) {
     this.host = host
@@ -364,7 +366,15 @@ export class GameRenderer {
     this._resizeObserver = new ResizeObserver((entries) => {
       for (const entry of entries) {
         const { width, height } = entry.contentRect
-        if (width > 0 && height > 0) {
+        // Guard: skip if size is zero or hasn't meaningfully changed (> 1px threshold).
+        // engine.resize() writes canvas.width/height which can mutate CSS layout size on
+        // canvases without explicit CSS dimensions, re-triggering this observer infinitely.
+        if (
+          width > 0 && height > 0 &&
+          (Math.abs(width - this._lastResizeWidth) > 1 || Math.abs(height - this._lastResizeHeight) > 1)
+        ) {
+          this._lastResizeWidth = width
+          this._lastResizeHeight = height
           this.host.engine.resize()
           console.log(`[GameRenderer] Canvas resized: ${Math.round(width)}x${Math.round(height)}`)
         }

--- a/src/main.ts
+++ b/src/main.ts
@@ -59,28 +59,14 @@ async function bootstrap(): Promise<void> {
 /**
  * Setup resize handling for the canvas
  */
-function setupResizeHandler(canvas: HTMLCanvasElement, engine: Engine | WebGPUEngine): void {
-  // Use ResizeObserver for proper canvas resize detection
-  const resizeObserver = new ResizeObserver((entries) => {
-    for (const entry of entries) {
-      if (entry.target === canvas) {
-        // Debounce resize calls
-        requestAnimationFrame(() => {
-          engine.resize()
-          console.log('[Resize] Canvas resized:', canvas.width, 'x', canvas.height)
-        })
-      }
-    }
-  })
-
-  resizeObserver.observe(canvas)
-
-  // Fallback to window resize event
+function setupResizeHandler(_canvas: HTMLCanvasElement, engine: Engine | WebGPUEngine): void {
+  // ResizeObserver is owned by GameRenderer (game-renderer.ts:setupResizeObserver).
+  // A second observer on the same canvas created an infinite resize loop: engine.resize()
+  // mutates canvas.width/height, which triggers the observer again on each call.
+  // Window resize is kept as a lightweight fallback for cases the element observer misses.
   window.addEventListener('resize', () => {
     engine.resize()
   })
-
-  console.log('[Resize] ResizeObserver setup complete')
 }
 
 /**


### PR DESCRIPTION
Two ResizeObserver instances watched the same canvas element. engine.resize() writes canvas.width/height; on canvases without explicit CSS dimensions this mutates CSS layout size, re-triggering both observers every frame and creating an infinite resize cascade (675 → 613 → 332 → 301 → 675 → ...).

Fix:
- main.ts: remove the duplicate ResizeObserver; keep only the window resize fallback. GameRenderer's observer is the authoritative handler.
- game-renderer.ts: add a >1px size-equality guard so the observer cannot self-trigger even in single-observer configurations.

https://claude.ai/code/session_019pCVRHvC7ouPa5KrrhAFVG

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved canvas resize behavior to prevent excessive resize operations triggered by minor dimension changes, enhancing performance and stability when resizing the application window.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ford442/pachinball/pull/140)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->