### PR TITLE
fix: replace require() with static ESM imports in game-scenario.ts

### DIFF
--- a/src/game/game-scenario.ts
+++ b/src/game/game-scenario.ts
@@ -12,13 +12,11 @@ import type { HapticManager } from '../game-elements/haptics'
 import type { ZoneTriggerSystem } from '../game-elements/zone-trigger-system'
 import type { AdventureManager } from './game-adventure'
 import type { TableMapManager } from './game-maps'
-import { getScenario } from '../game-elements'
+import { getScenario, getZoneConfig, ZoneTriggerSystem as ZoneTriggerSystemClass } from '../game-elements'
 import { getMaterialLibrary } from '../materials'
 import { resolveVideoUrl } from './game-utils'
 import { TABLE_MAPS } from '../shaders/lcd-table'
 import type { DynamicScenario, ScenarioZone, WorldZone, ZoneMechanic } from '../game-elements'
-
-declare const require: any
 
 export interface ScenarioHost {
   readonly scene: Scene | null
@@ -86,8 +84,7 @@ export class GameScenario {
 
   startDynamicMode(): void {
     console.log('[Game] Starting Dynamic Mode with Zone System')
-    const ZT = require('../game-elements') as typeof import('../game-elements')
-    this.host.zoneTriggerSystem = new ZT.ZoneTriggerSystem(false)
+    this.host.zoneTriggerSystem = new ZoneTriggerSystemClass(false)
     const scenario = getScenario('samurai-realm')
     if (scenario) {
       this.loadScenario(scenario)
@@ -320,8 +317,7 @@ export class GameScenario {
     this.host.adventureManager?.handleZoneTransition(zone, previousZone, isMajor)
     if (isMajor) {
       this.host.mapManager?.getLCDTableState().triggerFeedbackEffect()
-      const ZT = require('../game-elements') as typeof import('../game-elements')
-      const currentZoneConfig = ZT.getZoneConfig(zone)
+      const currentZoneConfig = getZoneConfig(zone)
       if (this.host.scene) {
         const matLib = getMaterialLibrary(this.host.scene)
         matLib.updateLCDTableEmissive(currentZoneConfig.primaryColor, currentZoneConfig.glowIntensity)


### PR DESCRIPTION
Two dynamic require('../game-elements') calls crashed at runtime with "require is not defined" in the Vite/ESM browser bundle. Both were covered by a `declare const require: any` shim that silenced TS but not the runtime.

ZoneTriggerSystem and getZoneConfig are both re-exported from '../game-elements' index; upgrade to static imports and remove the declare shim.

https://claude.ai/code/session_019pCVRHvC7ouPa5KrrhAFVG

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Internal code improvements to enhance maintainability and consistency in module handling.

**Note:** No user-visible changes in this release.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ford442/pachinball/pull/141)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->