### PR TITLE
fix: eliminate non-uniform control flow before textureSample in WebGPU shaders

### DIFF
--- a/src/shaders/crt-effect.ts
+++ b/src/shaders/crt-effect.ts
@@ -96,27 +96,26 @@ export const crtEffectShader = {
     void main(void) {
       vec2 curvedUV = applyCurvature(vUV, uCurvature);
 
-      // Sample before any non-uniform branch: WGSL (WebGPU) requires textureSample to be
-      // called in uniform control flow. The bounds-check below contains a per-fragment early
-      // return, which would make all subsequent textureSample calls non-uniform. Sampling
-      // first is safe — out-of-bounds fragments discard the result immediately after.
-      float r = texture2D(textureSampler, curvedUV + vec2(uChromaticAberration * 0.01, 0.0)).r;
-      float g = texture2D(textureSampler, curvedUV).g;
-      float b = texture2D(textureSampler, curvedUV - vec2(uChromaticAberration * 0.01, 0.0)).b;
+      // WebGPU (WGSL) requires textureSample to be called in uniform control flow —
+      // i.e. unconditionally, without any preceding branch on a per-fragment value.
+      // Clamping the UV keeps sampling in-bounds; the inBounds mask below blacks out
+      // fragments that fall outside the curved screen area without using a branch.
+      vec2 sampledUV = clamp(curvedUV, 0.0, 1.0);
+      float r = texture2D(textureSampler, sampledUV + vec2(uChromaticAberration * 0.01, 0.0)).r;
+      float g = texture2D(textureSampler, sampledUV).g;
+      float b = texture2D(textureSampler, sampledUV - vec2(uChromaticAberration * 0.01, 0.0)).b;
       vec3 color = vec3(r, g, b);
 
-      // Discard if outside screen bounds (for curvature)
-      if (curvedUV.x < 0.0 || curvedUV.x > 1.0 || curvedUV.y < 0.0 || curvedUV.y > 1.0) {
-        gl_FragColor = vec4(0.0, 0.0, 0.0, 1.0);
-        return;
-      }
-      
-      // Modern bloom/glow for bright elements
+      // Branchless out-of-bounds mask: 1.0 inside screen, 0.0 outside.
+      // step(a,b) = 1 when b >= a; all four conditions must pass.
+      float inBounds = step(0.0, curvedUV.x) * step(curvedUV.x, 1.0)
+                     * step(0.0, curvedUV.y) * step(curvedUV.y, 1.0);
+
+      // Modern bloom/glow (uGlow is uniform so this branch is uniform control flow)
       if (uGlow > 0.0) {
         float brightness = (color.r + color.g + color.b) / 3.0;
-        if (brightness > 0.5) {
-          color += color * brightness * uGlow * 0.8;
-        }
+        // Branchless bright-pixel boost via step instead of if (brightness > 0.5)
+        color += color * brightness * uGlow * 0.8 * step(0.5, brightness);
         color = color * (1.0 + uGlow * 0.2);
       }
 
@@ -127,23 +126,23 @@ export const crtEffectShader = {
       // Apply scanlines (soft for modern screens)
       float scan = scanlines(curvedUV, uScanlineIntensity);
       color *= scan;
-      
+
       // Apply vignette
       float vig = vignette(curvedUV, uVignette);
       color *= vig;
-      
-      // Add subtle noise/static
+
+      // Add subtle noise/static (uNoise is uniform — branch is fine)
       if (uNoise > 0.0) {
         float noise = rand(curvedUV + uTime) * uNoise;
         color += noise;
       }
-      
-      // Add occasional flicker
+
+      // Add occasional flicker (uFlicker is uniform — branch is fine)
       if (uFlicker > 0.0) {
         float flicker = 1.0 - (rand(vec2(uTime * 10.0, 0.0)) * uFlicker * 0.1);
         color *= flicker;
       }
-      
+
       // Modern color grading for LCD/OLED vibrancy
       float luminance = dot(color, vec3(0.299, 0.587, 0.114));
 
@@ -159,7 +158,8 @@ export const crtEffectShader = {
       // Contrast enhancement via S-curve
       color = pow(color, vec3(0.95)) + pow(color, vec3(2.1)) * 0.05;
 
-      gl_FragColor = vec4(color, 1.0);
+      // Apply out-of-bounds mask: black outside the curved screen area
+      gl_FragColor = vec4(color * inBounds, 1.0);
     }
   `
 }

--- a/src/shaders/jackpotOverlay.ts
+++ b/src/shaders/jackpotOverlay.ts
@@ -155,14 +155,14 @@ export const jackpotOverlayPostProcessFragment = `
     }
 
     void main(void) {
-        // UV glitch distortion replaces vertex displacement from the mesh-based variant
+        // WebGPU (WGSL) requires textureSample in uniform control flow.
+        // Compute glitch offset branchlessly so texture2D is always called
+        // unconditionally; step() replaces the per-fragment if-branches.
         vec2 uv = vUV;
-        if (uGlitchIntensity > 0.0) {
-            float noiseVal = rand(vec2(uTime, uv.y * 10.0));
-            if (noiseVal > 0.9) {
-                uv.x += (rand(vec2(uv.x * 10.0, uTime)) - 0.5) * uGlitchIntensity * 0.02;
-            }
-        }
+        float noiseVal    = rand(vec2(uTime, uv.y * 10.0));
+        float glitchShift = (rand(vec2(uv.x * 10.0, uTime)) - 0.5) * uGlitchIntensity * 0.02;
+        // Apply shift only when noiseVal > 0.9 AND uGlitchIntensity > 0 (both branchless)
+        uv.x += glitchShift * step(0.9, noiseVal) * step(0.001, uGlitchIntensity);
 
         vec4 sceneColor = texture2D(textureSampler, uv);
         vec4 baseColor  = texture2D(myTexture, uv);


### PR DESCRIPTION
## Summary

- **CRT shader**: the previous fix (sampling before the bounds-check `if`) wasn't enough — the GLSL→WGSL transpiler expands short-circuit `||` into nested if-blocks, placing `textureSample` inside a branch that depends on `vUV` (a module-scope private variable, hence non-uniform). Fixed by clamping the sample UV to `[0,1]` and replacing the `if/return` out-of-bounds guard with a branchless `step()`-based mask applied at the final `gl_FragColor` write.
- **Jackpot PostProcess shader**: replaced `if (noiseVal > 0.9)` / `if (uGlitchIntensity > 0.0)` branches (which appeared before `texture2D` calls) with unconditional arithmetic using `step()` multipliers.

## Root cause

WGSL requires `textureSample` to be called from **uniform control flow** — all invocations in the quad must unconditionally reach the call. The GLSL→WGSL transpiler treats `varying vec2 vUV` as a module-scope private variable (non-uniform by definition). Any `if` whose condition traces back to `vUV` creates non-uniform control flow; `textureSample` inside or textually after such a branch (due to transpiler reordering) fails validation.

## Test plan

- [ ] Load the game in a WebGPU-capable browser (Chrome/Edge with `--enable-features=WebGPU`)
- [ ] Confirm no `GPUValidationError` / WGSL parse error in DevTools console
- [ ] Verify CRT post-process still shows correct curvature, chromatic aberration, and black border outside curved screen area
- [ ] Verify jackpot overlay glitch effect still animates correctly

https://claude.ai/code/session_015EpwZgNw1fQeqe2JKLLetG

---
_Generated by [Claude Code](https://claude.ai/code/session_015EpwZgNw1fQeqe2JKLLetG)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized shader rendering logic for improved compatibility and performance across graphics systems.
  * Streamlined visual effect distortion calculations to ensure consistent behavior and stability.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ford442/pachinball/pull/149?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->