### PR TITLE
Make the playfield visible by default (bypass heavy bloom pipeline)

### DIFF
--- a/src/game/game-renderer.ts
+++ b/src/game/game-renderer.ts
@@ -181,6 +181,17 @@ export class GameRenderer {
       return
     }
 
+    // Opt-in to the full DefaultRenderingPipeline via ?fullpp=1.
+    // The default pipeline ran HDR rendering with ACES tone-mapping, DoF
+    // (focusDistance 2500 — far past the table), vignette and color curves;
+    // on top of the lcdTable/crtPP/scanline post-processes the compounded
+    // effect was so dim the table was invisible. Skip it to keep the
+    // playfield readable.
+    if (!new URLSearchParams(window.location.search).has('fullpp')) {
+      console.log('[GameRenderer] Default lite mode: no DefaultRenderingPipeline; enable full pipeline with ?fullpp=1')
+      return
+    }
+
     const bloom = new DefaultRenderingPipeline('pachinbloom', true, scene, [tableCam])
     this.host.bloomPipeline = bloom
 


### PR DESCRIPTION
## Summary
- After the app boots and the user clicks **Start**, the canvas was rendering as an almost-black LCD/hex pattern: no table, flippers, ball, or launcher were visible.
- Root cause was the post-processing chain. The `DefaultRenderingPipeline` was running HDR rendering + ACES tone-mapping + DoF with `focusDistance: 2500` (well past the table) + a 0.4-weight black vignette + color curves, on top of the `lcdTable`, `scanline`, and `crtPP` post-processes (each contributing their own vignettes / subpixel / chromatic effects). Compounded, the framebuffer that reached the screen was effectively black; the lcdTable shader's procedural `uMapBlend = 0.5` hex pattern was the only thing visible.
- Verified by diff-bisecting via Playwright + screenshots: with the `DefaultRenderingPipeline` skipped, the bumpers, plunger, flippers, ramps, and ball became clearly visible underneath the existing LCD/CRT stylization.

## Change
- `setupPostProcessing` now skips the full bloom pipeline by default. Pass `?fullpp=1` to opt back in (`?nopp=1` still disables everything for debugging).
- All the heavy-pipeline configuration is preserved behind that flag — no settings deleted, just gated.

## Test plan
- [x] `npm run build` — TypeScript + Vite build clean
- [x] `npm test` (Vitest) — 73/73 pass
- [x] Playwright smoke: click **Start**, screenshot canvas → table, bumpers, plunger, flippers visible (previously: black with hex LCD overlay only)
- [ ] Manual: confirm `?fullpp=1` still loads (post-processing chain unchanged when enabled)

https://claude.ai/code/session_01M3PizmsLrrB4NkeGkJ4LbT

---
_Generated by [Claude Code](https://claude.ai/code/session_01M3PizmsLrrB4NkeGkJ4LbT)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optional configuration to enable enhanced post-processing visual effects. The renderer now provides optimized performance by default while allowing users to opt into full visual post-processing capabilities.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ford442/pachinball/pull/152?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->