### PR TITLE
fix: remove external CDN dependencies blocking offline startup

### DIFF
--- a/src/materials/material-core.ts
+++ b/src/materials/material-core.ts
@@ -133,23 +133,6 @@ export class MaterialLibraryBase {
         console.log('[MaterialLibrary] Environment texture loaded and cached')
       })
 
-      // Guard against empty/corrupt files that never become ready
-      const timeoutId = setTimeout(() => {
-        if (!envTexture.isReady() || envTexture.getSize().width === 0) {
-          console.warn('[MaterialLibrary] Environment texture not ready after timeout, using CDN fallback')
-          if (this.scene.environmentTexture === envTexture) {
-            this.scene.environmentTexture = null
-          }
-          this.textureCache.delete(envPath)
-          envTexture.dispose()
-          this.loadFallbackEnvironmentTexture(envPath)
-        }
-      }, 500)
-
-      envTexture.onLoadObservable.add(() => {
-        clearTimeout(timeoutId)
-      })
-
       // Cache for reuse
       this.textureCache.set(envPath, envTexture)
 
@@ -157,28 +140,6 @@ export class MaterialLibraryBase {
       this.scene.environmentIntensity = TIER_ENV_INTENSITY[this._qualityTier]
     } catch (err) {
       console.warn('[MaterialLibrary] Failed to load environment texture:', err)
-      this.loadFallbackEnvironmentTexture(envPath)
-    }
-  }
-
-  /**
-   * Load a proper prefiltered environment texture from Babylon.js CDN.
-   * Unlike RawCubeTexture, this provides correct mipmaps for PBR IBL
-   * so metallic materials don't render black.
-   */
-  private loadFallbackEnvironmentTexture(cacheKey: string): void {
-    const cdnUrl = 'https://assets.babylonjs.com/environments/environmentSpecular.env'
-    try {
-      const fallback = CubeTexture.CreateFromPrefilteredData(cdnUrl, this.scene)
-      fallback.name = 'fallbackEnv'
-      fallback.onLoadObservable.add(() => {
-        console.log('[MaterialLibrary] CDN fallback environment texture loaded')
-      })
-      this.textureCache.set(cacheKey, fallback)
-      this.scene.environmentTexture = fallback
-      this.scene.environmentIntensity = TIER_ENV_INTENSITY[this._qualityTier]
-    } catch (err) {
-      console.warn('[MaterialLibrary] Failed to load CDN fallback environment texture:', err)
       this.scene.environmentTexture = null
       this.scene.environmentIntensity = Math.min(0.4, TIER_ENV_INTENSITY[this._qualityTier])
     }

--- a/src/style.css
+++ b/src/style.css
@@ -1,4 +1,3 @@
-@import url('https://fonts.googleapis.com/css2?family=Orbitron:wght@400;700;900&display=swap');
 
 :root {
   /* Cabinet sizing – 1:1.1 aspect ratio for immersive 3D view */


### PR DESCRIPTION
## Summary

The game was failing to start cleanly in offline / sandboxed environments because two external resources were unreachable:

1. `fonts.googleapis.com` — Orbitron font `@import` in `src/style.css`
2. `assets.babylonjs.com/environments/environmentSpecular.env` — Babylon.js CDN environment-texture fallback in `MaterialLibrary`

The latter was especially harmful: `loadEnvironmentTexture()` had a 500 ms readiness timeout that fired even when the local `public/textures/environment.env` was loading fine, then triggered an unreachable CDN fetch.

## Changes

- Drop the Google Fonts `@import`; CSS already falls back to `sans-serif`.
- Remove the CDN fallback path and the 500 ms timeout in `src/materials/material-core.ts`. The local prefiltered env texture is the single source of truth; on outright failure we leave `environmentTexture = null` with a dimmed intensity.

## Verification

- `npm run build` ✓
- `npm test` — 73/73 pass
- Playwright probe: clean startup, `MaterialLibrary] Environment texture loaded and cached`, state transitions `MENU -> PLAYING` with **zero** failed external requests and zero page errors.

## Test plan

- [ ] `npm run dev` and confirm playfield renders with PBR reflections
- [ ] Confirm UI text still legible without Orbitron (falls back to sans-serif)


---
_Generated by [Claude Code](https://claude.ai/code/session_018uarJrPSWBSEeysVEQc8LN)_