### PR TITLE
refactor(materials): migrate hardcoded colors/intensities to Visual Language System

### DIFF
--- a/src/materials/material-ball.ts
+++ b/src/materials/material-ball.ts
@@ -9,6 +9,7 @@ import {
   METALLIC,
   ROUGHNESS,
   CLEARCOAT,
+  INTENSITY,
   QualityTier,
   color,
   emissive,
@@ -40,7 +41,7 @@ export class BallMaterials extends MaterialLibraryBase {
    * Enhanced chrome ball with map-reactive emissive glow
    * Creates a glass/metallic hybrid that reacts to the current LCD map color
    */
-  getEnhancedChromeBallMaterial(mapColorHex: string = '#00d9ff'): PBRMaterial {
+  getEnhancedChromeBallMaterial(mapColorHex: string = PALETTE.CYAN): PBRMaterial {
     const cacheKey = `enhancedBall_${mapColorHex}`
     return this.getCachedPBR(cacheKey, () => {
       const mat = new PBRMaterial('enhancedBallMat', this.scene)
@@ -125,7 +126,7 @@ export class BallMaterials extends MaterialLibraryBase {
       mat.environmentIntensity = 1.3  // Higher reflectivity
 
       // Subtle gold emissive for premium glow (pulsed by BallManager)
-      mat.emissiveColor = emissive(PALETTE.GOLD, 0.2)
+      mat.emissiveColor = emissive(PALETTE.GOLD, INTENSITY.AMBIENT)
       mat.emissiveIntensity = 0.2
 
       // Clear coat for shine (skipped on LOW tier)

--- a/src/materials/material-core.ts
+++ b/src/materials/material-core.ts
@@ -26,6 +26,7 @@ import {
   QualityTier,
   TIER_ENV_INTENSITY,
   TIER_TEXTURE_SIZE,
+  ROUGHNESS,
 } from '../game-elements/visual-language'
 
 export interface TextureSet {
@@ -190,7 +191,7 @@ export class MaterialLibraryBase {
     const ctx = tex.getContext()
 
     // Base smooth metal in green channel (POLISHED = 0.05)
-    const baseVal = Math.round(0.05 * 255)
+    const baseVal = Math.round(ROUGHNESS.POLISHED * 255)
     ctx.fillStyle = `rgb(0, ${baseVal}, 0)`
     ctx.fillRect(0, 0, size, size)
 
@@ -411,3 +412,4 @@ export class MaterialLibraryBase {
     console.groupEnd()
   }
 }
+

--- a/src/materials/material-interactive.ts
+++ b/src/materials/material-interactive.ts
@@ -13,6 +13,7 @@ import {
   ROUGHNESS,
   CLEARCOAT,
   CATEGORIES,
+  FEEDER_STYLES,
   QualityTier,
   color,
   emissive,
@@ -123,7 +124,7 @@ export class InteractiveMaterials extends MaterialLibraryBase {
     return this.getCachedPBR('flipper', () => {
       const mat = new PBRMaterial('flipperMat', this.scene)
       mat.albedoColor = color(PALETTE.GOLD)
-      mat.emissiveColor = emissive('#ff8800', INTENSITY.AMBIENT)
+      mat.emissiveColor = emissive(FEEDER_STYLES.GAUSS_CANNON.base, INTENSITY.AMBIENT)
       mat.metallic = METALLIC.MID
       mat.roughness = ROUGHNESS.SATIN
       mat.environmentIntensity = 0.7
@@ -165,7 +166,7 @@ export class InteractiveMaterials extends MaterialLibraryBase {
       mat.clearCoat.roughness = 0.2
       
       // Subtle emissive edge glow (neon accent)
-      mat.emissiveColor = emissive('#ff6600', 0.2)
+      mat.emissiveColor = emissive('#ff6600', INTENSITY.AMBIENT)
       mat.emissiveIntensity = 0.4
 
       // Anisotropy for brushed metal look on striking surface

--- a/src/materials/material-metallic.ts
+++ b/src/materials/material-metallic.ts
@@ -5,6 +5,7 @@
 import { PBRMaterial, Color3, DynamicTexture } from '@babylonjs/core'
 import { MaterialLibraryBase } from './material-core'
 import {
+  PALETTE,
   SURFACES,
   METALLIC,
   ROUGHNESS,
@@ -97,7 +98,7 @@ export class MetallicMaterials extends MaterialLibraryBase {
   getGlossBlackMaterial(): PBRMaterial {
     return this.getCachedPBR('glossBlack', () => {
       const mat = new PBRMaterial('glossBlackMat', this.scene)
-      mat.albedoColor = new Color3(0.02, 0.02, 0.03)
+      mat.albedoColor = color(SURFACES.VOID)
       mat.metallic = 0.3
       mat.roughness = 0.2
       mat.environmentIntensity = 1.0
@@ -173,7 +174,7 @@ export class MetallicMaterials extends MaterialLibraryBase {
   getGoldMaterial(): PBRMaterial {
     return this.getCachedPBR('gold', () => {
       const mat = new PBRMaterial('goldMat', this.scene)
-      mat.albedoColor = new Color3(1.0, 0.84, 0.0)
+      mat.albedoColor = color(PALETTE.GOLD)
       mat.metallic = 1.0
       mat.roughness = 0.15
       mat.environmentIntensity = 1.2
@@ -233,7 +234,7 @@ export class MetallicMaterials extends MaterialLibraryBase {
    * Enhanced peg material with map-reactive emissive tips
    * Used for pachinko field pins
    */
-  getEnhancedPinMaterial(mapColorHex: string = '#00d9ff'): PBRMaterial {
+  getEnhancedPinMaterial(mapColorHex: string = PALETTE.CYAN): PBRMaterial {
     const cacheKey = `enhancedPin_${mapColorHex}`
     return this.getCachedPBR(cacheKey, () => {
       const mat = new PBRMaterial('enhancedPinMat', this.scene)
@@ -273,7 +274,7 @@ export class MetallicMaterials extends MaterialLibraryBase {
   /**
    * Enhanced rail material - smooth curved metal with map-reactive accent
    */
-  getEnhancedRailMaterial(mapColorHex: string = '#00d9ff'): PBRMaterial {
+  getEnhancedRailMaterial(mapColorHex: string = PALETTE.CYAN): PBRMaterial {
     const cacheKey = `enhancedRail_${mapColorHex}`
     return this.getCachedPBR(cacheKey, () => {
       const mat = new PBRMaterial('enhancedRailMat', this.scene)

--- a/src/materials/material-structural.ts
+++ b/src/materials/material-structural.ts
@@ -121,7 +121,7 @@ export class StructuralMaterials extends MaterialLibraryBase {
     return this.getCachedPBR('cabinetInterior', () => {
       const mat = new PBRMaterial('cabinetInteriorMat', this.scene)
       // Dark felt/plastic interior to absorb light
-      mat.albedoColor = new Color3(0.02, 0.02, 0.03)
+      mat.albedoColor = color(SURFACES.VOID)
       mat.metallic = METALLIC.LOW
       mat.roughness = ROUGHNESS.ROUGH
       mat.environmentIntensity = 0.1
@@ -423,7 +423,7 @@ export class StructuralMaterials extends MaterialLibraryBase {
     mat.microSurface = 0.3
 
     // Dark albedo - the LCD emits light, doesn't reflect it
-    mat.albedoColor = new Color3(0.02, 0.02, 0.03)
+    mat.albedoColor = color(SURFACES.VOID)
 
     // No transparency - this is a solid LCD panel
     mat.alpha = 1.0


### PR DESCRIPTION
## Summary
Mechanical migration of remaining hardcoded color hex strings and raw numeric intensity/roughness values in `src/materials/` to the centralized Visual Language System constants.

## Changes
- **material-ball.ts**: default `mapColorHex` → `PALETTE.CYAN`; gold-plated emissive `0.2` → `INTENSITY.AMBIENT`
- **material-core.ts**: micro-roughness base `0.05` → `ROUGHNESS.POLISHED`
- **material-interactive.ts**: flipper emissive `#ff8800` → `FEEDER_STYLES.GAUSS_CANNON.base`; `0.2` → `INTENSITY.AMBIENT`
- **material-metallic.ts**: gloss black albedo `Color3(0.02,0.02,0.03)` → `color(SURFACES.VOID)`; gold albedo `Color3(1.0,0.84,0.0)` → `color(PALETTE.GOLD)`; default params → `PALETTE.CYAN`
- **material-structural.ts**: cabinet interior & LCD albedo `Color3(0.02,0.02,0.03)` → `color(SURFACES.VOID)`

## Verification
- `npx tsc -b --noEmit` passes cleanly
- Zero logic changes; colors preserved exactly where no semantic constant existed

## Scope
This is intentionally small — focused on the `src/materials/` module only. Follow-up PRs will cover `src/effects/`, `src/objects/`, `src/game-elements/`, etc.