### PR TITLE
refactor(effects): migrate hardcoded colors to Visual Language System

### DIFF
--- a/src/effects/cabinet-lighting.ts
+++ b/src/effects/cabinet-lighting.ts
@@ -8,7 +8,7 @@
 import { Color3, PointLight, Vector3, type Scene } from '@babylonjs/core'
 import type { EventBus } from '../game/event-bus'
 import { DisplayState } from '../game-elements/display-config'
-import { QualityTier } from '../game-elements/visual-language'
+import { PALETTE, color, QualityTier } from '../game-elements/visual-language'
 
 export interface CabinetLightingConfig {
   enableEdgeLighting: boolean
@@ -165,7 +165,7 @@ export class CabinetLighting {
         break
 
       case DisplayState.JACKPOT:
-        edgeColor = new Color3(0.0, 1.0, 1.0) // Bright cyan
+        edgeColor = color(PALETTE.CYAN) // Bright cyan
         edgeIntensity = 1.0
         underColor = new Color3(0.0, 0.8, 1.0)
         underIntensity = 0.8
@@ -179,7 +179,7 @@ export class CabinetLighting {
         break
 
       case DisplayState.ADVENTURE:
-        edgeColor = new Color3(0.6, 0.2, 1.0) // Rich purple
+        edgeColor = color(PALETTE.PURPLE) // Rich purple
         edgeIntensity = 0.8
         underColor = new Color3(0.2, 0.8, 1.0) // Cyan accent
         underIntensity = 0.4

--- a/src/effects/effects-core.ts
+++ b/src/effects/effects-core.ts
@@ -17,6 +17,7 @@ import type { DefaultRenderingPipeline } from '@babylonjs/core/PostProcesses/Ren
 import type { CabinetLight, ShardParticle } from '../game-elements/types'
 import {
   PALETTE,
+  SURFACES,
   TEMPERATURE,
   FOG_STATES,
   LIGHTING_STATES,
@@ -64,10 +65,10 @@ export class EffectsSystem {
   // Atmosphere state tracking
   private currentAtmosphereState = 'IDLE'
   private targetFogDensity = 0.005
-  private targetFogColor: Color3 = color('#080818')
+  private targetFogColor: Color3 = color(SURFACES.PLAYFIELD)
   private targetKeyColor: Color3 = color(TEMPERATURE.NORMAL)
   private targetRimIntensity: number = LIGHTING.RIM.intensity
-  private targetRimColor: Color3 = color('#80bfff')
+  private targetRimColor: Color3 = color(LIGHTING.RIM.color)
 
   // Jackpot Variables
   jackpotTimer = 0
@@ -263,7 +264,7 @@ export class EffectsSystem {
     ip.vignetteWeight = 1.5
   }
 
-  triggerScreenPulse(colorHex = '#ffffff', intensity = 0.8, durationMs = 400): void {
+  triggerScreenPulse(colorHex: string = PALETTE.WHITE, intensity = 0.8, durationMs = 400): void {
     // LCD post-process flash (if available)
     if (this.lcdPostProcess) {
       this.lcdPostProcess.flashIntensity = intensity
@@ -725,7 +726,7 @@ export class EffectsSystem {
     this.addCameraShake(shakeIntensity)
 
     // Flash vignette with color
-    const flashColor = color || (intensity === 'jackpot' ? '#ff0088' : '#00d9ff')
+    const flashColor = color || (intensity === 'jackpot' ? '#ff0088' : PALETTE.CYAN)
     const flashDuration = intensity === 'jackpot' ? 500 : intensity === 'heavy' ? 300 : 200
     this.flashVignette(flashColor, flashDuration)
 

--- a/src/effects/effects-particles.ts
+++ b/src/effects/effects-particles.ts
@@ -1,4 +1,5 @@
 import { Scene, Vector3, ParticleSystem, Color4, Texture } from '@babylonjs/core'
+import { PALETTE } from '../game-elements/visual-language'
 
 export class ParticleEffects {
   private scene: Scene
@@ -43,7 +44,7 @@ export class ParticleEffects {
     }
   }
 
-  spawnBumperSpark(position: Vector3, color = '#00d9ff'): void {
+  spawnBumperSpark(position: Vector3, color: string = PALETTE.CYAN): void {
     if (!this.poolInited) {
       this.initBumperSparkPool(12)
     }


### PR DESCRIPTION
## Summary
Continues the Visual Language audit in `src/effects/`, migrating hardcoded hex strings and `Color3` literals to centralized `PALETTE`, `SURFACES`, and `LIGHTING` constants.

## Changes
- **effects-core.ts**:
  - `targetFogColor` default `'#080818'` → `SURFACES.PLAYFIELD`
  - `targetRimColor` `'#80bfff'` → `LIGHTING.RIM.color`
  - `triggerScreenPulse` default `'#ffffff'` → `PALETTE.WHITE` (param typed as `string` to preserve call-site compatibility)
  - `flashVignette` fallback `'#00d9ff'` → `PALETTE.CYAN`

- **effects-particles.ts**:
  - `spawnBumperSpark` default `'#00d9ff'` → `PALETTE.CYAN` (param typed as `string`)

- **cabinet-lighting.ts**:
  - `JACKPOT` edge `Color3(0, 1, 1)` → `color(PALETTE.CYAN)`
  - `ADVENTURE` edge `Color3(0.6, 0.2, 1)` → `color(PALETTE.PURPLE)`

## Verification
- `npx tsc -b --noEmit` passes cleanly
- Zero logic changes

## Note on Type Annotations
`PALETTE` values are `as const` string literals. To prevent downstream callers from seeing narrowed literal types, affected function parameters now have explicit `: string` annotations.