### PR TITLE
fix: defer GamePhysicsController until EventBus exists

### DIFF
--- a/src/game.ts
+++ b/src/game.ts
@@ -311,7 +311,6 @@ export class Game {
       this.hud = new GameHUD(this as unknown as HUDHost)
       this.mapCabinet = new GameMapCabinet(this as unknown as MapCabinetHost)
       this.updateHUD()
-      this.physicsController = new GamePhysicsController(this as unknown as PhysicsHost)
 
       this.settingsUI.setupSettingsUI()
       this.debugHelper.updateDeveloperSettingsVisibility()
@@ -329,6 +328,7 @@ export class Game {
         },
       })
       this.stateManager.setEventBus(this.eventBus)
+      this.physicsController = new GamePhysicsController(this as unknown as PhysicsHost)
     })
 
     await this.runCheckpointStage('physics', () => this.physics.init())


### PR DESCRIPTION
## Summary

Bootstrap was failing at the `core_helpers` stage with:

```
TypeError: Cannot read properties of undefined (reading 'on')
    at new GamePhysicsController
```

`GamePhysicsController`'s constructor subscribes to `host.eventBus.on('points:awarded', ...)` etc. (added in #163), but it was being instantiated in the `core_helpers` stage — one stage before `state_setup` creates `this.eventBus`. So `host.eventBus` was `undefined` at construction time.

## Fix

Move `new GamePhysicsController(...)` into the `state_setup` stage, immediately after `this.eventBus` is created.

## Test plan
- [ ] `npm run dev` — page loads past `core_helpers`
- [ ] Bumper hits award points (validates `points:awarded` subscription)
- [ ] Flash / shake effects still trigger


---
_Generated by [Claude Code](https://claude.ai/code/session_01TmeiX5CQEFsboScneZdUaZ)_