### PR TITLE
Set up dev environment + add Cursor Cloud notes to AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -363,3 +363,16 @@ When making changes that touch authentication, API keys, or asset URLs, use `imp
 
 10. **Stale Portal Handles in `portalSensorHandleSet`**  
     Every path that deactivates a portal must unregister its handle. The PORTAL_ENTERED handler covers the happy path, but `switchToTrack()` and `activateExitPortal()` replacement also call `deactivateExitPortal()` — use the `PORTAL_DEACTIVATED` event pattern.
+
+---
+
+## Cursor Cloud specific instructions
+
+This is a frontend-only Vite + TypeScript app — there is no backend service to run for local development. Dependencies (`npm install` + the Playwright Chromium browser) are refreshed automatically by the cloud update script.
+
+Standard commands are in section 2 (`npm run dev`, `npm run build`, `npm run lint`, `npm test`, `npx playwright test`). Non-obvious caveats:
+
+- **Dev server:** `npm run dev` serves on `http://localhost:5173`. Run it in a long-lived terminal (e.g. tmux) before Playwright E2E specs — `playwright.config.ts` has **no** `webServer` block, so it will not auto-start the dev server; tests will fail/hang against `localhost:5173` if nothing is serving.
+- **Tests:** `npm test` (Vitest, Node env, Babylon/Rapier mocked) needs no server. `*.spec.ts` files are Playwright E2E and DO need the dev server running.
+- **Renderer for automation:** WebGPU canvases can't be read by Playwright/computer-use tooling. Append `?renderer=webgl2` to the URL (e.g. `http://localhost:5173/?renderer=webgl2`) when driving the game from automation or capturing screenshots.
+- **`npm run build` and WASM:** `build` runs `tsc -b && vite build && npm run build:wasm`. The `build:wasm` step compiles an *optional* C++ physics engine (`native/`) via Emscripten and **gracefully skips with exit 0 when `emcc` is not installed** — so `npm run build` succeeds in this environment without Emscripten. Gameplay physics uses Rapier WASM (bundled via npm), independent of that optional C++ module.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Sets up and verifies the development environment for Pachinball (Vite + TypeScript + Babylon.js + Rapier WASM). This is a frontend-only app with no backend service.

The only code change is documentation: a new `## Cursor Cloud specific instructions` section in `AGENTS.md` capturing non-obvious caveats discovered during setup.

## Environment setup

- Update script (auto-run on VM startup): `npm install` + `npx playwright install chromium`.
- No system/service dependencies required to develop locally.

## Verification

All standard workflows were run successfully:

- `npm run lint` — 0 errors (3 pre-existing warnings)
- `npm test` — 378 passed (34 files)
- `npm run build` — succeeds (`build:wasm` gracefully skips without Emscripten)
- `npm run dev` — serves on `http://localhost:5173`
- `npx playwright test tests/verify_prism_core.spec.ts` — passed

### Hello-world gameplay

Played the game in-browser via WebGL2 renderer: loaded the menu, started the game, launched a ball with the plunger, and operated the flippers with physics responding correctly.

<a href="https://cursor.com/agents/bc-ae7cbfa8-0c16-452e-92c6-158e7b84187e/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fpachinball_gameplay_demo.mp4"><img src="https://cursor.com/artifacts/c/art-42b94fb5-16e6-4698-abb5-0387733e2114" alt="pachinball_gameplay_demo.mp4" /></a>

![Menu](https://cursor.com/artifacts/c/art-40a4b553-d12b-4e07-9a0a-844e4680c829)
![Ball launched](https://cursor.com/artifacts/c/art-198274ff-eeb0-434f-8800-3bdbaa8e74e7)
![Active play](https://cursor.com/artifacts/c/art-09deb144-4b6a-4cf3-91e7-6a543cd57b72)

Note: the score stayed at 0 during play (ball didn't hit scoring zones); this is gameplay behavior, not an environment issue, and out of scope for setup.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-ae7cbfa8-0c16-452e-92c6-158e7b84187e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ae7cbfa8-0c16-452e-92c6-158e7b84187e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

