### PR TITLE
Fix subdirectory deploy, API path, and WebGPU rendering on test.1ink.us

### DIFF
--- a/src/display/display-lcd-overlay.ts
+++ b/src/display/display-lcd-overlay.ts
@@ -14,6 +14,7 @@ import type { Mesh, Scene, TransformNode } from '@babylonjs/core'
 import { DisplayState, type DisplayConfig } from './display-types'
 import { DISPLAY_LAYER_Z } from './display-layer-depth'
 import { PALETTE, STATE_COLORS, QualityTier } from '../game-elements/visual-language'
+import { resolveAssetUrl } from '../game/game-utils'
 import type { DisplayOverlay } from './display-overlay'
 
 interface WalkByCharacter {
@@ -183,9 +184,10 @@ export class DisplayLcdOverlayLayer {
   private preloadSplashImages(): void {
     const paths = ['/assets/backbox/splash1.png', '/assets/backbox/splash2.png']
     for (const path of paths) {
+      const resolved = resolveAssetUrl(path) ?? path
       const img = new Image()
-      img.onerror = () => console.warn(`[DisplayLcd] Failed to load splash: ${path}`)
-      img.src = path
+      img.onerror = () => console.warn(`[DisplayLcd] Failed to load splash: ${resolved}`)
+      img.src = resolved
       this.splashImages.push(img)
     }
   }

--- a/src/game-elements/map-system.ts
+++ b/src/game-elements/map-system.ts
@@ -5,7 +5,7 @@
  * Merges hardcoded fallback maps with dynamically uploaded shader-maps.
  */
 
-import { API_BASE, apiFetch } from '../config'
+import { apiFetch } from '../config'
 import { TABLE_MAPS, type TableMapConfig, type TableMapType } from '../shaders/lcd-table'
 
 export interface DynamicMapConfig extends TableMapConfig {
@@ -58,7 +58,7 @@ export class MapSystem {
     }
 
     try {
-      const remoteMaps = await apiFetch<DynamicMapConfig[]>(`${API_BASE}/maps`)
+      const remoteMaps = await apiFetch<DynamicMapConfig[]>('/maps')
       if (!remoteMaps || remoteMaps.length === 0) {
         this.loaded = true
         console.log(`[MapSystem] Loaded ${this.maps.size} maps (hardcoded/cache only)`)

--- a/src/game-elements/sound-system.ts
+++ b/src/game-elements/sound-system.ts
@@ -13,6 +13,7 @@ import { Vector3 } from '@babylonjs/core'
 import { BallType } from '../config'
 import type { EventBus } from '../game/event-bus'
 import { GameConfig } from '../config'
+import { resolveAssetUrl } from '../game/game-utils'
 import {
   createImpactVoiceProfile,
   getPortalMotifFrequencies,
@@ -701,12 +702,11 @@ export class SoundSystem {
 
   private async loadGoldBallSounds(): Promise<void> {
     // Try to load actual sound files
-    const base = (import.meta.env.BASE_URL as string) || './'
     const soundFiles = [
-      { name: 'gold-plated-spawn', url: `${base}sounds/gold-spawn.mp3` },
-      { name: 'solid-gold-spawn', url: `${base}sounds/solid-gold-spawn.mp3` },
-      { name: 'gold-plated-collect', url: `${base}sounds/gold-collect.mp3` },
-      { name: 'solid-gold-collect', url: `${base}sounds/solid-gold-collect.mp3` }
+      { name: 'gold-plated-spawn', url: resolveAssetUrl('sounds/gold-spawn.mp3')! },
+      { name: 'solid-gold-spawn', url: resolveAssetUrl('sounds/solid-gold-spawn.mp3')! },
+      { name: 'gold-plated-collect', url: resolveAssetUrl('sounds/gold-collect.mp3')! },
+      { name: 'solid-gold-collect', url: resolveAssetUrl('sounds/solid-gold-collect.mp3')! }
     ]
 
     for (const { name, url } of soundFiles) {

--- a/src/game/game-utils.ts
+++ b/src/game/game-utils.ts
@@ -1,16 +1,21 @@
 import { Color3 } from '@babylonjs/core'
 
 /**
- * Resolve video URLs for Vite subdirectory deployment.
+ * Resolve static asset URLs for Vite subdirectory deployment.
  * Prepends import.meta.env.BASE_URL so assets load correctly under any base path.
  * Absolute URLs (http...) are returned as-is.
  */
-export function resolveVideoUrl(videoPath: string | undefined): string | undefined {
-  if (!videoPath) return undefined
-  if (videoPath.startsWith('http')) return videoPath
+export function resolveAssetUrl(assetPath: string | undefined): string | undefined {
+  if (!assetPath) return undefined
+  if (/^https?:\/\//i.test(assetPath)) return assetPath
   const base = (import.meta.env.BASE_URL as string) || '/'
-  const cleanPath = videoPath.startsWith('/') ? videoPath.slice(1) : videoPath
+  const cleanPath = assetPath.startsWith('/') ? assetPath.slice(1) : assetPath
   return `${base}${cleanPath}`
+}
+
+/** @deprecated Use resolveAssetUrl — kept for existing video call sites. */
+export function resolveVideoUrl(videoPath: string | undefined): string | undefined {
+  return resolveAssetUrl(videoPath)
 }
 
 /**

--- a/src/game/index.ts
+++ b/src/game/index.ts
@@ -47,7 +47,7 @@ export { GameSystemsInitializer } from './game-systems-init'
 export { GameDisposer } from './game-disposer'
 export { GameHUD, type HUDHost } from './game-hud'
 export { GameMapCabinet, type MapCabinetHost } from './game-map-cabinet'
-export { hexToColor3, resolveVideoUrl } from './game-utils'
+export { hexToColor3, resolveAssetUrl, resolveVideoUrl } from './game-utils'
 
 export { getMapRegistry, getMapConfigById, getMapsByLayout, resetMapRegistry, type MapConfig } from './map-registry'
 export { LevelLoader, type LevelLoaderDeps, type LoadResult } from './level-loader'

--- a/src/main.ts
+++ b/src/main.ts
@@ -156,7 +156,10 @@ async function createEngine(canvas: HTMLCanvasElement): Promise<Engine | WebGPUE
   const engineOptions = {
     antialias: true,
     preserveDrawingBuffer: true,
-    stencil: true
+    stencil: true,
+    // SSAO + DoF + bloom MRT exceeds the WebGPU default 32-byte/sample limit on
+    // many adapters; request adapter maximums so post-processing pipelines validate.
+    setMaximumLimits: true,
   }
 
   const preference = getRendererPreference()

--- a/src/objects/object-decoration.ts
+++ b/src/objects/object-decoration.ts
@@ -16,6 +16,7 @@ import { COLLISION_GROUP_PRESETS } from '../game-elements/physics'
 import { getMaterialLibrary } from '../materials'
 import type { PhysicsBinding } from '../game-elements/types'
 import { color, emissive, PALETTE, INTENSITY } from '../game-elements/visual-language'
+import { resolveAssetUrl } from '../game/game-utils'
 
 export class DecorationBuilder {
   private scene: Scene
@@ -1054,22 +1055,22 @@ export function applyTableDecorations(
   // ========================================================================
   // LAYER 1 — PROJECTED DECALS (high-level graphic language)
   // ========================================================================
-  createNeonDecal(scene, playfieldMesh, new Vector3(0, -0.99, 5), '/assets/textures/decals/circuit-center.png', {
+  createNeonDecal(scene, playfieldMesh, new Vector3(0, -0.99, 5), resolveAssetUrl('/assets/textures/decals/circuit-center.png')!, {
     size: new Vector3(7.5, 11, 0.08),
     emissiveIntensity: 1.35,
     zOffset: -0.6
   })
-  createNeonDecal(scene, playfieldMesh, new Vector3(-5.5, -0.99, -6), '/assets/textures/decals/lane-arrow-l.png', {
+  createNeonDecal(scene, playfieldMesh, new Vector3(-5.5, -0.99, -6), resolveAssetUrl('/assets/textures/decals/lane-arrow-l.png')!, {
     size: new Vector3(2.2, 3.5, 0.06),
     emissiveIntensity: 1.6,
     zOffset: -0.7
   })
-  createNeonDecal(scene, playfieldMesh, new Vector3(5.5, -0.99, -6), '/assets/textures/decals/lane-arrow-r.png', {
+  createNeonDecal(scene, playfieldMesh, new Vector3(5.5, -0.99, -6), resolveAssetUrl('/assets/textures/decals/lane-arrow-r.png')!, {
     size: new Vector3(2.2, 3.5, 0.06),
     emissiveIntensity: 1.6,
     zOffset: -0.7
   })
-  createNeonDecal(scene, playfieldMesh, new Vector3(0, -0.99, 14), '/assets/textures/decals/hazard-chevron.png', {
+  createNeonDecal(scene, playfieldMesh, new Vector3(0, -0.99, 14), resolveAssetUrl('/assets/textures/decals/hazard-chevron.png')!, {
     size: new Vector3(9, 4, 0.05),
     emissiveIntensity: 1.1,
     zOffset: -0.9

--- a/tests/map-system.test.ts
+++ b/tests/map-system.test.ts
@@ -71,7 +71,7 @@ describe('MapSystem', () => {
     const system = new MapSystem()
     await system.fetchAll()
 
-    expect(apiFetchMock).toHaveBeenCalledWith('https://example.test/api/maps')
+    expect(apiFetchMock).toHaveBeenCalledWith('/maps')
     expect(system.isLoaded).toBe(true)
     expect(system.isLoading).toBe(false)
     expect(system.loadError).toBeNull()


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Fixes three issues seen in production at `test.1ink.us/pachinball`:

1. **Broken WebGPU rendering** — Post-processing (SSAO + DoF + bloom) exceeded the default 32-byte/sample color attachment limit, causing hundreds of `GPUValidationError` messages and ~29 FPS. Engine creation now requests adapter maximum limits via `setMaximumLimits: true`.

2. **Double API prefix** — `MapSystem` called `apiFetch(\`${API_BASE}/maps\`)` while `apiFetch` already prepends `API_BASE`, producing `/api/api/maps` (404) when `VITE_API_URL=/api`.

3. **Subdirectory asset 404s** — Splash images, decal textures, and sound files used root-absolute paths (`/assets/...`) that ignore the `/pachinball/` deploy path. Added `resolveAssetUrl()` (generalizing the existing video helper) and applied it to affected call sites.

## Notes

- Missing asset files (splash PNGs, decal textures, gold-ball MP3s) will still 404 until uploaded to the server, but paths will now resolve correctly under the subdirectory once present.
- Sound system already falls back to synthesized audio when MP3s are missing.
- Decal textures are optional — missing files produce no-op visuals.

## Test plan

- [x] `npm test` (438 tests)
- [x] `npm run build`
- [x] `npm run lint`
- [ ] Redeploy to `test.1ink.us/pachinball` and verify WebGPU console is clean
- [ ] Confirm `/api/maps` (not `/api/api/maps`) in network tab
- [ ] Confirm asset URLs include `./` or `/pachinball/` base prefix
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-cf770648-4085-478e-aecc-7d5249cc7345"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-cf770648-4085-478e-aecc-7d5249cc7345"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

