### PR TITLE
Flipper controls: 1/0 keys and visible rotation on tilted playfield

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ npm install
 npm run dev
 ```
 
-Open http://localhost:5173/. Use **Left Shift** / **Right Shift** for the flippers, hold **Space** or **Enter** to charge and release the plunger, and press **R** to reset the ball.
+Open http://localhost:5173/. Use **1** / **0** for the flippers, hold **Space** or **Enter** to charge and release the plunger, and press **R** to reset the ball.
 
 ## Campaign Mode
 

--- a/index.html
+++ b/index.html
@@ -48,7 +48,7 @@
         <h1>NEXUS</h1>
         <div id="start-screen" class="screen">
           <p>Best: <span id="best-score-menu">0</span></p>
-          <p>Left/Right Shift to Flip</p>
+          <p>1 / 0 to Flip</p>
           <p>Space or Enter to Launch</p>
           <button id="start-btn">Start Game</button>
           <button id="settings-btn">Settings</button>
@@ -223,7 +223,7 @@
 
     </div>
 
-    <div id="controls-hint">Controls — Shift: Flippers &nbsp;|&nbsp; Space/Enter: Launch &nbsp;|&nbsp; W/Z/Slash: Nudge &nbsp;|&nbsp; P: Pause &nbsp;|&nbsp; R: Reset</div>
+    <div id="controls-hint">Controls — 1/0: Flippers &nbsp;|&nbsp; Space/Enter: Launch &nbsp;|&nbsp; W/Z/Slash: Nudge &nbsp;|&nbsp; P: Pause &nbsp;|&nbsp; R: Reset</div>
 
     <div id="power-toast" class="toast hidden"></div>
 

--- a/src/game-elements/input.ts
+++ b/src/game-elements/input.ts
@@ -55,6 +55,10 @@ export class InputHandler {
   private gamepadManager: GamepadManager | null = null
   private lastGamepadState: GamepadState | null = null
 
+  // Sustained keyboard flipper holds (re-applied each frame for motor + visuals)
+  private flipperLeftHeld = false
+  private flipperRightHeld = false
+
   // Latency tracking for input-to-response timing
   private latencyMetrics: LatencyMetrics = {
     samples: [],
@@ -396,6 +400,22 @@ export class InputHandler {
   }
   
   /**
+   * Re-queue held flipper keys each frame so joint motors stay active and
+   * hold-to-charge stiffness can ramp while the key is down.
+   */
+  pollHeldFlipperKeys(): void {
+    if (this.getState() !== GameState.PLAYING || this.getAdventureActive()) return
+    if (this.getTiltActive()) return
+
+    if (this.flipperLeftHeld) {
+      this.queueInput('flipperLeft', true)
+    }
+    if (this.flipperRightHeld) {
+      this.queueInput('flipperRight', true)
+    }
+  }
+
+  /**
    * Update plunger charge (call each frame while held)
    */
   updatePlungerCharge(): void {
@@ -474,13 +494,15 @@ export class InputHandler {
       this.cancelPlungerCharge()
     }
 
-    if (!adventureActive && event.code === 'ShiftLeft') {
+    if (!adventureActive && event.code === 'Digit1') {
       if (this.getTiltActive()) return
+      this.flipperLeftHeld = true
       this.queueInput('flipperLeft', true)
     }
 
-    if (!adventureActive && event.code === 'ShiftRight') {
+    if (!adventureActive && event.code === 'Digit0') {
       if (this.getTiltActive()) return
+      this.flipperRightHeld = true
       this.queueInput('flipperRight', true)
     }
 
@@ -529,11 +551,13 @@ export class InputHandler {
       this.cancelPlungerCharge()
     }
 
-    if (!adventureActive && event.code === 'ShiftLeft') {
+    if (!adventureActive && event.code === 'Digit1') {
+      this.flipperLeftHeld = false
       this.queueInput('flipperLeft', false)
     }
 
-    if (!adventureActive && event.code === 'ShiftRight') {
+    if (!adventureActive && event.code === 'Digit0') {
+      this.flipperRightHeld = false
       this.queueInput('flipperRight', false)
     }
 

--- a/src/game/game-input.ts
+++ b/src/game/game-input.ts
@@ -115,12 +115,12 @@ export class GameInputManager {
     const isPlaying = gameState === 1 // GameState.PLAYING = 1
     const adventureActive = this.config.getAdventureActive?.() ?? false
 
-    // Dynamic map switching (Digit1-9)
+    // Dynamic map switching (Digit2-9 → maps 1-8; Digit0/1 are flippers)
     if (e.code.startsWith('Digit') && isPlaying) {
-      const index = parseInt(e.code.replace('Digit', ''), 10) - 1
-      if (index >= 0) {
+      const digit = parseInt(e.code.replace('Digit', ''), 10)
+      if (digit >= 2 && digit <= 9) {
         e.preventDefault()
-        this.config.onMapSwitch?.(index)
+        this.config.onMapSwitch?.(digit - 2)
       }
       return
     }
@@ -260,6 +260,9 @@ export class GameInputManager {
   update(): void {
     // Poll gamepad input
     this.inputHandler.pollGamepad()
+
+    // Keep flipper motors active while 1/0 are held
+    this.inputHandler.pollHeldFlipperKeys()
 
     // Update plunger charge if held
     this.inputHandler.updatePlungerCharge()

--- a/src/game/game-physics-controller.ts
+++ b/src/game/game-physics-controller.ts
@@ -2,7 +2,7 @@
  * Game Physics Controller — Physics stepping, collision processing, nudge/tilt, ball loss.
  */
 
-import { Vector3, Quaternion } from '@babylonjs/core'
+import { Vector3, Quaternion, TransformNode, Matrix, TmpVectors } from '@babylonjs/core'
 import type { Mesh } from '@babylonjs/core'
 import type * as RAPIER from '@dimforge/rapier3d-compat'
 
@@ -168,6 +168,8 @@ export class GamePhysicsController {
   private readonly prevPoses: Map<RAPIER.RigidBody, { pos: Vector3; rot: Quaternion }> = new Map()
   private readonly scratchCurrPos = new Vector3()
   private readonly scratchCurrRot = new Quaternion()
+  private readonly scratchInterpPos = new Vector3()
+  private readonly scratchInterpRot = new Quaternion()
 
   constructor(host: PhysicsHost) {
     this.host = host
@@ -435,16 +437,11 @@ export class GamePhysicsController {
       }
 
       if (alpha < 1 && !body.isSleeping()) {
-        Vector3.LerpToRef(prev.pos, this.scratchCurrPos, alpha, mesh.position)
-        if (!mesh.rotationQuaternion) mesh.rotationQuaternion = new Quaternion()
-        Quaternion.SlerpToRef(prev.rot, this.scratchCurrRot, alpha, mesh.rotationQuaternion)
+        const interpPos = Vector3.LerpToRef(prev.pos, this.scratchCurrPos, alpha, this.scratchInterpPos)
+        Quaternion.SlerpToRef(prev.rot, this.scratchCurrRot, alpha, this.scratchInterpRot)
+        this.applyBindingPose(mesh, interpPos, this.scratchInterpRot)
       } else {
-        mesh.position.set(pos.x, pos.y, pos.z)
-        if (!mesh.rotationQuaternion) {
-          mesh.rotationQuaternion = new Quaternion(rot.x, rot.y, rot.z, rot.w)
-        } else {
-          mesh.rotationQuaternion.set(rot.x, rot.y, rot.z, rot.w)
-        }
+        this.applyBindingPose(mesh, this.scratchCurrPos, this.scratchCurrRot)
       }
 
       prev.pos.copyFrom(this.scratchCurrPos)
@@ -455,6 +452,28 @@ export class GamePhysicsController {
     for (const body of this.prevPoses.keys()) {
       if (!liveBodies.has(body)) this.prevPoses.delete(body)
     }
+  }
+
+  /** Apply a physics-world pose to a bound mesh, respecting playfield parenting. */
+  private applyBindingPose(mesh: TransformNode, pos: Vector3, rot: Quaternion): void {
+    if (!mesh.parent) {
+      mesh.position.copyFrom(pos)
+      if (!mesh.rotationQuaternion) {
+        mesh.rotationQuaternion = rot.clone()
+      } else {
+        mesh.rotationQuaternion.copyFrom(rot)
+      }
+      return
+    }
+
+    const parentWorld = mesh.parent.computeWorldMatrix(true)
+    parentWorld.invertToRef(TmpVectors.Matrix[0])
+    Matrix.ComposeToRef(mesh.scaling, rot, pos, TmpVectors.Matrix[1])
+    TmpVectors.Matrix[1].multiplyToRef(TmpVectors.Matrix[0], TmpVectors.Matrix[2])
+    if (!mesh.rotationQuaternion) {
+      mesh.rotationQuaternion = new Quaternion()
+    }
+    TmpVectors.Matrix[2].decompose(mesh.scaling, mesh.rotationQuaternion, mesh.position)
   }
 
   stepPhysics(

--- a/src/game/game-scene-builder.ts
+++ b/src/game/game-scene-builder.ts
@@ -89,6 +89,11 @@ export class GameSceneBuilder {
     }
     ballManager.createMainBall()
 
+    // Parent flipper assemblies into the tilted playfield group (world pose preserved).
+    for (const { mesh } of gameObjects.getAllFlippers().values()) {
+      mesh.setParent(playfieldGroup, true)
+    }
+
     // Reparent walls + flippers into the tilted visual group.
     // Ball is excluded — its position is overwritten each frame from Rapier world coords.
     scene.meshes

--- a/tests/input-handler.test.ts
+++ b/tests/input-handler.test.ts
@@ -48,8 +48,8 @@ describe('InputHandler', () => {
   })
 
   describe('handleKeyDown', () => {
-    it('queues flipperLeft when ShiftLeft is pressed', () => {
-      handler.handleKeyDown(new KeyboardEvent('keydown', { code: 'ShiftLeft' }))
+    it('queues flipperLeft when Digit1 is pressed', () => {
+      handler.handleKeyDown(new KeyboardEvent('keydown', { code: 'Digit1' }))
       const frame = handler.processBufferedInputs()
       expect(frame.flipperLeft).toBe(true)
     })
@@ -60,8 +60,8 @@ describe('InputHandler', () => {
       expect(frame.flipperLeft).toBeNull()
     })
 
-    it('queues flipperRight when ShiftRight is pressed', () => {
-      handler.handleKeyDown(new KeyboardEvent('keydown', { code: 'ShiftRight' }))
+    it('queues flipperRight when Digit0 is pressed', () => {
+      handler.handleKeyDown(new KeyboardEvent('keydown', { code: 'Digit0' }))
       const frame = handler.processBufferedInputs()
       expect(frame.flipperRight).toBe(true)
     })
@@ -74,14 +74,14 @@ describe('InputHandler', () => {
 
     it('does not queue flipper inputs when tilt is active', () => {
       callbacks.getTiltActive.mockReturnValue(true)
-      handler.handleKeyDown(new KeyboardEvent('keydown', { code: 'ShiftLeft' }))
+      handler.handleKeyDown(new KeyboardEvent('keydown', { code: 'Digit1' }))
       const frame = handler.processBufferedInputs()
       expect(frame.flipperLeft).toBeNull()
     })
 
     it('does not queue gameplay inputs when state is MENU', () => {
       callbacks.getState.mockReturnValue(GameState.MENU)
-      handler.handleKeyDown(new KeyboardEvent('keydown', { code: 'ShiftLeft' }))
+      handler.handleKeyDown(new KeyboardEvent('keydown', { code: 'Digit1' }))
       const frame = handler.processBufferedInputs()
       expect(frame.flipperLeft).toBeNull()
     })
@@ -124,17 +124,25 @@ describe('InputHandler', () => {
       handler.handleKeyDown(new KeyboardEvent('keydown', { code: 'KeyH' }))
       expect(callbacks.onAdventureToggle).toHaveBeenCalledTimes(1)
     })
+
+    it('re-queues flipperLeft while Digit1 is held', () => {
+      handler.handleKeyDown(new KeyboardEvent('keydown', { code: 'Digit1' }))
+      handler.processBufferedInputs()
+      handler.pollHeldFlipperKeys()
+      const frame = handler.processBufferedInputs()
+      expect(frame.flipperLeft).toBe(true)
+    })
   })
 
   describe('handleKeyUp', () => {
-    it('queues flipperLeft=false when ShiftLeft is released', () => {
-      handler.handleKeyUp(new KeyboardEvent('keyup', { code: 'ShiftLeft' }))
+    it('queues flipperLeft=false when Digit1 is released', () => {
+      handler.handleKeyUp(new KeyboardEvent('keyup', { code: 'Digit1' }))
       const frame = handler.processBufferedInputs()
       expect(frame.flipperLeft).toBe(false)
     })
 
-    it('queues flipperRight=false when ShiftRight is released', () => {
-      handler.handleKeyUp(new KeyboardEvent('keyup', { code: 'ShiftRight' }))
+    it('queues flipperRight=false when Digit0 is released', () => {
+      handler.handleKeyUp(new KeyboardEvent('keyup', { code: 'Digit0' }))
       const frame = handler.processBufferedInputs()
       expect(frame.flipperRight).toBe(false)
     })

--- a/tests/keyboard-input.spec.ts
+++ b/tests/keyboard-input.spec.ts
@@ -3,8 +3,8 @@ import { test, expect } from '@playwright/test';
 // Real keyboard-path coverage for flippers and the plunger.
 //
 // Correct bindings (src/game-elements/input.ts):
-//   - ShiftLeft  = left flipper
-//   - ShiftRight = right flipper
+//   - Digit1     = left flipper
+//   - Digit0     = right flipper
 //   - Enter      = plunger charge (hold) / launch (release)
 //   - Space      = plunger charge (same action as Enter), not a flipper key
 //
@@ -66,12 +66,12 @@ async function startGame(page: import('@playwright/test').Page) {
 }
 
 test.describe('Keyboard Input Pipeline', () => {
-  test('ShiftLeft rotates the left flipper joint via the real keyboard path', async ({ page }) => {
+  test('Digit1 rotates the left flipper joint via the real keyboard path', async ({ page }) => {
     test.setTimeout(120_000);
 
     const consoleErrors = await startGame(page);
 
-    // Snapshot the flipper joint rotation, hold ShiftLeft via real keyboard
+    // Snapshot the flipper joint rotation, hold Digit1 via real keyboard
     // events, then wait a few rAF ticks (which drive the physics step) before
     // comparing — exactly as a player's keypress would.
     const flipperBefore = await page.evaluate(() => {
@@ -81,7 +81,7 @@ test.describe('Keyboard Input Pipeline', () => {
     });
     expect(flipperBefore).not.toBeNull();
 
-    await page.keyboard.down('ShiftLeft');
+    await page.keyboard.down('Digit1');
 
     const flipperAfter = await page.evaluate(() => {
       const g = (window as any).game;
@@ -97,7 +97,7 @@ test.describe('Keyboard Input Pipeline', () => {
       });
     });
 
-    await page.keyboard.up('ShiftLeft');
+    await page.keyboard.up('Digit1');
 
     // Flipper should have rotated (Y axis is the rotation axis for the revolute joint)
     const flipperDelta = Math.abs((flipperAfter?.bodyY ?? 0) - (flipperBefore?.bodyY ?? 0));


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Fixes flipper controls and visibility:

1. **Flipper keys → `1` / `0`** — Replaces Left/Right Shift (which triggers Windows Sticky Keys) with number-row keys:
   - `1` = left flipper
   - `0` = right flipper

2. **Flipper visuals now rotate with physics** — Flipper assemblies are parented to the tilted `playfieldGroup`, and mesh sync converts Rapier world poses into local playfield space so rotation is visible on the LCD table.

3. **Sustained motor updates** — While `1`/`0` are held, flipper joint motors are re-applied every frame (not just on keydown), keeping motion active and allowing hold-to-charge stiffness to ramp.

4. **Map hotkey adjustment** — LCD map switching moves to `2`–`9` (maps 1–8) so `1` is free for the left flipper. Map 1 is still selectable via the on-screen buttons or `M` to cycle.

## Test plan

- [x] `npm test` (439 tests)
- [x] `npm run build`
- [x] `npm run lint`
- [ ] Hold `1` / `0` in play and confirm flippers swing visibly on the playfield
- [ ] Confirm Shift no longer activates flippers
- [ ] Confirm `2`–`9` still switch LCD maps during play
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-cf770648-4085-478e-aecc-7d5249cc7345"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-cf770648-4085-478e-aecc-7d5249cc7345"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

