### PR TITLE
fix: consolidation review — ambient a11y + dev-tool gating

### DIFF
--- a/src/effects/effects-core.ts
+++ b/src/effects/effects-core.ts
@@ -28,7 +28,7 @@ import {
   STATE_COLORS,
   INTENSITY,
 } from '../game-elements/visual-language'
-import { EffectsConfig, BallType } from '../config'
+import { EffectsConfig, BallType, GameConfig } from '../config'
 import type * as RAPIER from '@dimforge/rapier3d-compat'
 import { DEFAULT_ACCESSIBILITY, type AccessibilityConfig } from '../game-elements/accessibility-config'
 import { ParticleEffects } from './effects-particles'
@@ -250,7 +250,7 @@ export class EffectsSystem {
       this.targetTrackBloom = profile.atmosphere.bloomWeight
       this.targetTrackVignette = profile.atmosphere.vignetteWeight
       this.currentCabinetColor = profile.particles.hitPrimary
-      if (this.accessibility.effectIntensity > 0) {
+      if (this.shouldEnableTrackAmbientEffects()) {
         this.trackAmbientEffects.applyProfile(profile)
       } else {
         this.trackAmbientEffects.applyProfile(null)
@@ -281,6 +281,19 @@ export class EffectsSystem {
 
   registerAccessibility(config: AccessibilityConfig): void {
     this.accessibility = config
+    this.trackAmbientEffects.setAccessibilityFlags({
+      photosensitiveMode: GameConfig.accessibility.photosensitiveMode,
+      reducedMotion: config.reducedMotion,
+    })
+    if (this.activeTrackProfile) {
+      this.setTrackThemeProfile(this.activeTrackProfile)
+    }
+  }
+
+  private shouldEnableTrackAmbientEffects(): boolean {
+    if (this.accessibility.reducedMotion) return false
+    if (GameConfig.accessibility.photosensitiveMode) return false
+    return this.accessibility.effectIntensity > 0
   }
 
   registerSceneLights(keyLight: DirectionalLight, rimLight: DirectionalLight, bounceLight: PointLight): void {

--- a/src/effects/track-ambient-effects.ts
+++ b/src/effects/track-ambient-effects.ts
@@ -18,20 +18,41 @@ export class TrackAmbientEffects {
   private flickerTimer = 0
   private profile: TrackThemeProfile | null = null
   private photosensitiveMode = false
+  private reducedMotion = false
 
   constructor(scene: Scene) {
     this.scene = scene
   }
 
+  setAccessibilityFlags(flags: { photosensitiveMode: boolean; reducedMotion: boolean }): void {
+    const changed =
+      this.photosensitiveMode !== flags.photosensitiveMode ||
+      this.reducedMotion !== flags.reducedMotion
+    this.photosensitiveMode = flags.photosensitiveMode
+    this.reducedMotion = flags.reducedMotion
+    if (!changed) return
+
+    const profile = this.profile
+    this.clear()
+    if (profile && this.shouldRenderAmbient(profile)) {
+      this.applyProfile(profile)
+    }
+  }
+
+  /** @deprecated Use setAccessibilityFlags */
   setPhotosensitiveMode(enabled: boolean): void {
-    this.photosensitiveMode = enabled
-    if (enabled) this.clear()
+    this.setAccessibilityFlags({ photosensitiveMode: enabled, reducedMotion: this.reducedMotion })
+  }
+
+  private shouldRenderAmbient(profile: TrackThemeProfile): boolean {
+    if (this.photosensitiveMode || this.reducedMotion) return false
+    return profile.particles.ambient !== 'none'
   }
 
   applyProfile(profile: TrackThemeProfile | null): void {
     this.clear()
     this.profile = profile
-    if (!profile || profile.particles.ambient === 'none' || this.photosensitiveMode) {
+    if (!profile || !this.shouldRenderAmbient(profile)) {
       this.activeStyle = 'none'
       return
     }
@@ -59,7 +80,9 @@ export class TrackAmbientEffects {
   }
 
   update(dt: number): number {
-    if (!this.profile || this.activeStyle === 'none') return 1
+    if (!this.profile || this.activeStyle === 'none' || this.photosensitiveMode || this.reducedMotion) {
+      return 1
+    }
 
     this.flickerTimer += dt
 

--- a/src/game-elements/index.ts
+++ b/src/game-elements/index.ts
@@ -168,7 +168,7 @@ export {
   PHYSICS_TUNING_SLIDERS,
   type PhysicsTuningKey,
 } from './physics-tuning'
-export { PhysicsTuningPanel, isPhysicsTuningQueryEnabled } from './physics-tuning-panel'
+export { PhysicsTuningPanel, isPhysicsTuningQueryEnabled, isPhysicsTuningEnabled } from './physics-tuning-panel'
 export { PerformanceMonitor, type PerformanceMetrics } from './performance-monitor'
 
 // Adventure goal & progression systems

--- a/src/game-elements/physics-tuning-panel.ts
+++ b/src/game-elements/physics-tuning-panel.ts
@@ -168,5 +168,14 @@ function formatTuningValue(key: PhysicsTuningKey, value: number): string {
 
 export function isPhysicsTuningQueryEnabled(): boolean {
   if (typeof window === 'undefined') return false
-  return new URLSearchParams(window.location.search).has('tune')
+  const params = new URLSearchParams(window.location.search)
+  if (!params.has('tune')) return false
+  return import.meta.env.DEV || params.has('debug')
+}
+
+export function isPhysicsTuningEnabled(
+  enabledInSettings: boolean,
+  queryEnabled = isPhysicsTuningQueryEnabled(),
+): boolean {
+  return queryEnabled || enabledInSettings
 }

--- a/src/game.ts
+++ b/src/game.ts
@@ -94,7 +94,7 @@ import { GameInputActions, type InputActionsHost } from './game/game-input-actio
 import { GameScenario, type ScenarioHost } from './game/game-scenario'
 import { GameSlotAdventure, type SlotAdventureHost } from './game/game-slot-adventure'
 import { GameSettingsUI, type SettingsUIHost } from './game/game-settings-ui'
-import { PhysicsTuningPanel, isPhysicsTuningQueryEnabled } from './game-elements/physics-tuning-panel'
+import { PhysicsTuningPanel, isPhysicsTuningEnabled } from './game-elements/physics-tuning-panel'
 import { GameDebug, type DebugHost } from './game/game-debug'
 import { GameLifecycle, type LifecycleHost } from './game/game-lifecycle'
 import { GameSystemsInitializer } from './game/game-systems-init'
@@ -329,8 +329,8 @@ export class Game {
       this.scenarioManager = new GameScenario(this as unknown as ScenarioHost)
       this.slotAdventure = new GameSlotAdventure(this as unknown as SlotAdventureHost)
       this.settingsUI = new GameSettingsUI(this as unknown as SettingsUIHost)
-      this.physicsTuningPanel = new PhysicsTuningPanel()
-      if (isPhysicsTuningQueryEnabled() || this.physicsTuningEnabledInSettings) {
+      if (isPhysicsTuningEnabled(this.physicsTuningEnabledInSettings)) {
+        this.physicsTuningPanel = new PhysicsTuningPanel()
         this.physicsTuningPanel.show()
       }
       this.debugHelper = new GameDebug(this as unknown as DebugHost)
@@ -663,6 +663,7 @@ export class Game {
     this.debugHelper.handleDebugHUDVisibilityChange(
       visible,
       () => {
+        this.eventBusLog.wire(this.eventBus)
         this.eventBusLog.setEnabled(true)
         this.performanceMonitor.setEnabled(true)
       },
@@ -671,6 +672,19 @@ export class Game {
         this.eventBusLog.clear()
       },
     )
+  }
+  ensurePhysicsTuningPanel(): PhysicsTuningPanel {
+    if (!this.physicsTuningPanel) {
+      this.physicsTuningPanel = new PhysicsTuningPanel()
+    }
+    return this.physicsTuningPanel
+  }
+  applyAccessibilitySettings(reducedMotion: boolean, photosensitiveMode: boolean): void {
+    this.accessibility = detectAccessibility({ reducedMotion, photosensitiveMode })
+    this.effects?.registerAccessibility(this.accessibility)
+    this.adventureMode?.setAccessibilityConfig(this.accessibility)
+    this.display?.setAccessibility(this.accessibility)
+    this.mapManager?.getLCDTableState().setPhotosensitiveMode(photosensitiveMode)
   }
   isDebugHUDAvailable(): boolean { return this.debugHelper.isDebugHUDAvailable() }
   isDebugHUDKeyboardEnabled(): boolean { return this.debugHelper.isDebugHUDKeyboardEnabled() }

--- a/src/game/game-settings-ui.ts
+++ b/src/game/game-settings-ui.ts
@@ -38,6 +38,8 @@ export interface SettingsUIHost {
   showDebugUI: boolean
 
   isDebugHUDAvailable(): boolean
+  ensurePhysicsTuningPanel(): PhysicsTuningPanel
+  applyAccessibilitySettings(reducedMotion: boolean, photosensitiveMode: boolean): void
   setScanlineWeight?(weight: number): void
   setScanlineEnabled?(enabled: boolean): void
   setScanlineIntensityMultiplier?(multiplier: number): void
@@ -166,6 +168,7 @@ export class GameSettingsUI {
 
     SettingsManager.save(newSettings)
     SettingsManager.applyToConfig(newSettings)
+    this.host.applyAccessibilitySettings(newSettings.reducedMotion, newSettings.photosensitiveMode)
     this.host.debugHUDEnabledInSettings = newSettings.enableDebugHUD
     this.applyScanlineEnabled(scanlineEnabled)
     this.applyScanlineIntensityMultiplier(scanlineIntensityMultiplier)
@@ -178,12 +181,10 @@ export class GameSettingsUI {
     }
 
     if (newSettings.enablePhysicsTuning) {
-      this.host.physicsTuningPanel?.show()
+      this.host.ensurePhysicsTuningPanel().show()
     } else {
       this.host.physicsTuningPanel?.hide()
     }
-
-    this.host.mapManager?.getLCDTableState().setPhotosensitiveMode(newSettings.photosensitiveMode)
 
     this.host.soundSystem.setMasterVolume(newSettings.masterVolume)
     this.host.soundSystem.setMusicVolume(newSettings.musicVolume)

--- a/src/game/game-systems-init.ts
+++ b/src/game/game-systems-init.ts
@@ -129,7 +129,9 @@ export class GameSystemsInitializer {
       })
       this.game.cabinetLighting.subscribeToEvents(this.game.eventBus)
 
-      this.game.eventBusLog.wire(this.game.eventBus)
+      if (this.game.debugHelper.isDebugHUDAvailable()) {
+        this.game.eventBusLog.wire(this.game.eventBus)
+      }
       this.game.performanceMonitor.setRendererBackend(
         (window as unknown as { currentRenderer?: string }).currentRenderer ??
           (this.game.engine.getClassName().toLowerCase().includes('webgpu') ? 'webgpu' : 'webgl2'),

--- a/tests/physics-tuning-panel.test.ts
+++ b/tests/physics-tuning-panel.test.ts
@@ -1,0 +1,26 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import {
+  isPhysicsTuningEnabled,
+  isPhysicsTuningQueryEnabled,
+} from '../src/game-elements/physics-tuning-panel'
+
+describe('physics tuning panel gating', () => {
+  afterEach(() => {
+    vi.unstubAllGlobals()
+    vi.unstubAllEnvs()
+  })
+
+  it('requires debug context for ?tune in production builds', () => {
+    vi.stubGlobal('window', { location: { search: '?tune=1' } })
+    vi.stubEnv('DEV', false)
+    expect(isPhysicsTuningQueryEnabled()).toBe(false)
+
+    vi.stubGlobal('window', { location: { search: '?tune=1&debug' } })
+    expect(isPhysicsTuningQueryEnabled()).toBe(true)
+  })
+
+  it('enables tuning from developer settings without a query param', () => {
+    expect(isPhysicsTuningEnabled(true, false)).toBe(true)
+    expect(isPhysicsTuningEnabled(false, false)).toBe(false)
+  })
+})

--- a/tests/track-ambient-effects.test.ts
+++ b/tests/track-ambient-effects.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from 'vitest'
+import type { Scene } from '@babylonjs/core'
+import { TrackAmbientEffects } from '../src/effects/track-ambient-effects'
+import { getTrackThemeProfile } from '../src/game-elements/track-theme-profiles'
+
+describe('TrackAmbientEffects accessibility', () => {
+  const scene = { uniqueId: 1 } as unknown as Scene
+  const cyberCore = getTrackThemeProfile('CYBER_CORE')
+
+  it('suppresses ambient particles and flicker when photosensitive mode is enabled', () => {
+    const effects = new TrackAmbientEffects(scene)
+    effects.setAccessibilityFlags({ photosensitiveMode: true, reducedMotion: false })
+    effects.applyProfile(cyberCore ?? null)
+
+    expect(effects.update(0.016)).toBe(1)
+    expect(effects.update(0.5)).toBe(1)
+  })
+
+  it('suppresses ambient particles and flicker when reduced motion is enabled', () => {
+    const effects = new TrackAmbientEffects(scene)
+    effects.setAccessibilityFlags({ photosensitiveMode: false, reducedMotion: true })
+    effects.applyProfile(cyberCore ?? null)
+
+    expect(effects.update(0.016)).toBe(1)
+  })
+
+  it('clears active ambient effects when accessibility flags tighten mid-session', () => {
+    const effects = new TrackAmbientEffects(scene)
+    effects.setAccessibilityFlags({ photosensitiveMode: false, reducedMotion: false })
+    effects.setAccessibilityFlags({ photosensitiveMode: true, reducedMotion: false })
+
+    expect(effects.update(0.25)).toBe(1)
+  })
+})


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Consolidation review (commits `04b0c9d` + `d1f377b`)

Post-merge architectural review of the ~1500-line codespace drop (pachinko-hall, track ambient effects, physics tuning panel, event-bus log, campaign persistence, teardown stats).

---

### Checklist results

#### 1. Are new panels/logging dev-gated?

| Component | Status | Notes |
|-----------|--------|-------|
| **EventBusLog** | ✅ OK | Recording only when Debug HUD is visible (`setEnabled` tied to HUD `onVisibilityChange`). Subscriptions were always wired at init — **fixed in this PR** to wire only when debug is available / on first HUD show. |
| **PhysicsTuningPanel** | ⚠️ → ✅ | Developer checkbox is behind `#developer-settings` (hidden unless `import.meta.env.DEV` or `?debug`). **Gap:** `?tune` worked in production and panel DOM was always created. **Fixed:** lazy init + `?tune` now requires DEV or `?debug`. |
| **Track teardown stats** | ✅ OK | Surfaced only via Debug HUD Campaign panel (`td meshes` / `td bodies` / `td lingering`). |

#### 2. Dead code / duplicated event logging?

- **No dead modules found.** `EventBusLog` complements (not duplicates) the existing Debug HUD — it adds a rolling **EventBus** panel while the HUD still shows aggregate campaign/physics state.
- Minor overhead: `eventBusLog.wire()` subscribed to ~15 events even when logging disabled — addressed by deferred wiring.

#### 3. Persistence schema versioning resilient?

- ✅ `migrateCampaignStorage()` handles legacy v1 (no `version` field) and normalizes via `sanitizeProgressionState()`.
- ✅ Vitest covers malformed input, unknown tracks, and v1 migration.
- ⚠️ **Naming nit:** `CAMPAIGN_STORAGE_KEY = '...v1'` while `CAMPAIGN_STORAGE_VERSION = 2`. Harmless but confusing — recommend a comment or rename only when willing to migrate keys.
- ⚠️ `unlockedRewardIds` from storage are filtered to catalog on load; unknown IDs in raw JSON are dropped at apply time (acceptable).
- No test for `version > CAMPAIGN_STORAGE_VERSION` warn-only path (low risk).

#### 4. Ambient effects respect `reducedMotion` / photosensitive?

- ❌ **Bug (pre-fix):** `TrackAmbientEffects.setPhotosensitiveMode()` existed but was **never called**. `reducedMotion` was not checked. `effectIntensity > 0` still allowed particles for reduced-motion (0.3) and photosensitive (0.45) profiles; electric-arc/neon **flicker** drove bloom/key light via `trackFlickerScale`.
- ✅ **Fixed in this PR:** `setAccessibilityFlags({ photosensitiveMode, reducedMotion })`, skip spawn + flicker, re-apply profile on flag change; `EffectsSystem.registerAccessibility()` propagates flags; settings save now calls `applyAccessibilitySettings()`.

#### 5. Track teardown stats wired into switch path?

- ✅ **Wired.** `AdventureMode.clearTrack()` populates `lastTeardownStats`; warns on `lingeringBodies > 0`; `GameDebug.buildDebugSnapshot()` feeds Debug HUD Campaign panel. Not orphaned.

#### 6. Config changes affect table balance unintentionally?

- ⚠️ **Intentional re-tune, but broad.** Not accidental wiring — defaults changed across core loop:

| Area | Change | Impact |
|------|--------|--------|
| Ball physics | restitution 0.78→0.76, friction/damping up | Slightly less lively roll |
| Bumpers | restitution 0.92→0.94 | Snappier hits |
| Flippers | strength 25k→32k, damping 1000→850 | Stronger, slightly less damped |
| Plunger | min 12→14, max 38→36 | Slightly higher floor, lower ceiling |
| Nudge | force 0.6→0.72, lift 0.3→0.22 | Stronger horizontal, less lift |
| Fever | threshold 10→12, expiry 1.5→2.0s | Harder to enter, longer window |
| Combo | max mult 5→6, window 2.5→2.8s | Higher ceiling |
| Gold swarm | 4→5 balls, quicker-collect 1.5×→2.0× | More base points per trigger |
| New `GAME_TUNING.obstacle.*` | scoring bases for toys | Adventure/table obstacle scoring only |

- **Physics tuning runtime:** `getPhysicsTuningValue()` is on the hot path for ball/flippers/plunger/nudge — overrides are **in-memory only** (not persisted), but panel/`?tune` could alter live feel during a session. Gating tightened in this PR.

---

### Changes in this PR

1. Track ambient VFX suppressed for `reducedMotion` + `photosensitiveMode`; flicker disabled.
2. `EffectsSystem.registerAccessibility()` + settings-save propagation.
3. Lazy `PhysicsTuningPanel` creation; `?tune` requires DEV or `?debug`.
4. Deferred `EventBusLog.wire()` until debug HUD available.
5. Tests: `track-ambient-effects.test.ts`, `physics-tuning-panel.test.ts`.

---

### Recommended follow-ups (not in this PR)

1. **Document balance pass** — changelog entry for `GAME_TUNING` / `GameConfig` physics deltas so playtesters know what shifted.
2. **Storage key comment** — clarify `CAMPAIGN_STORAGE_KEY` suffix vs `CAMPAIGN_STORAGE_VERSION`.
3. **Consider** extracting debug-only instrumentation (`EventBusLog`, teardown counters) behind a `DebugInstrumentation` facade to keep `game.ts` lean.
4. **Playtest** pachinko-hall + cyber-core with accessibility toggles on device.

---

### Test plan

- [x] `npm test` (497 tests, all green)
- [x] `npm run lint` / `tsc -b`
- [ ] Manual: enable photosensitive + reduced motion → enter adventure track with `electric-arc` ambient → confirm no particles/flicker
- [ ] Manual: production build `?tune=1` alone → panel hidden; `?tune=1&debug` → panel visible
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-2a2ff20e-b863-40e2-bdc0-642ce789b591"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-2a2ff20e-b863-40e2-bdc0-642ce789b591"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

