### PR TITLE
ci: add GitHub Actions workflow gating PRs + pushes to main (#283)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,85 @@
+name: CI
+
+# Gate every PR and every push to main. Nothing landed on main should be red here.
+# Mirrors the local swarm discipline (tsc -b, lint, vitest, build) so regressions are
+# caught before merge rather than after a direct-to-main push.
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+# Cancel superseded runs on the same ref to save minutes.
+concurrency:
+  group: ci-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  check:
+    name: typecheck / lint / test / build
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Typecheck
+        run: npx tsc -b
+
+      - name: Lint
+        run: npm run lint
+
+      - name: Unit tests (Vitest)
+        run: npx vitest run
+
+      # NOTE: intentionally `vite build`, NOT `npm run build`.
+      # `npm run build` chains `build:wasm` (scripts/build-wasm.sh), which needs Emscripten.
+      # emcc is not installed on the default runner, so WASM is kept out of this job; the
+      # localStorage physics-engine flag falls back to Rapier when the bundle is absent.
+      # This step still verifies the TS/Vite bundle compiles and links.
+      - name: Build (bundle only, no WASM)
+        run: npx vite build
+
+  # Optional smoke: full dev server + a couple of Playwright specs.
+  # `continue-on-error` while this stabilizes — a red e2e must NOT block merges yet.
+  # verify_prism_core.spec.ts hard-codes http://localhost:5173, so we run the real dev
+  # server on that port rather than relying on Playwright's baseURL. No webServer block is
+  # added to playwright.config.ts here (kept out of scope); the server is managed inline.
+  e2e:
+    name: playwright smoke (non-blocking)
+    runs-on: ubuntu-latest
+    continue-on-error: true
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Install Playwright Chromium
+        run: npx playwright install --with-deps chromium
+
+      - name: Start dev server
+        run: |
+          npm run dev &
+          # Poll the dev server until it answers on 5173 (max ~60s), then continue.
+          for i in $(seq 1 60); do
+            if curl -sf http://localhost:5173 >/dev/null; then
+              echo "dev server up after ${i}s"; exit 0
+            fi
+            sleep 1
+          done
+          echo "dev server did not start within 60s" >&2
+          exit 1
+
+      - name: Playwright smoke specs
+        run: npx playwright test tests/verify_prism_core.spec.ts tests/basic-gameplay.spec.ts

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -49,6 +49,20 @@ npm run preview
 npx playwright test
 ```
 
+### Continuous Integration
+
+`.github/workflows/ci.yml` gates every pull request and every push to `main`. The blocking
+`check` job runs, in order: `npm ci` → `npx tsc -b` → `npm run lint` → `npx vitest run` →
+`npx vite build`. **PRs must stay green** — do not merge red. A second, non-blocking
+(`continue-on-error`) `e2e` job runs a Playwright smoke against a live dev server.
+
+Notes:
+- CI runs `npx vite build`, **not** `npm run build` — the latter chains `build:wasm`
+  (Emscripten), which isn't installed on the runner. The C++ WASM bundle is intentionally
+  out of CI; the physics-engine flag falls back to Rapier when the bundle is absent.
+- Enabling branch protection on `main` (require the `check` job) is recommended so ungated
+  direct-to-`main` pushes can't regress the build.
+
 ---
 
 ## 3. Directory & Module Map

--- a/README.md
+++ b/README.md
@@ -16,6 +16,15 @@ npm run dev
 
 Open http://localhost:5173/. Use **1** / **0** for the flippers, hold **Space** or **Enter** to charge and release the plunger, and press **R** to reset the ball.
 
+## Continuous Integration
+
+Every pull request and push to `main` is gated by GitHub Actions (`.github/workflows/ci.yml`):
+`tsc -b`, `npm run lint`, `npx vitest run`, and `npx vite build`. **Keep PRs green.** A
+non-blocking Playwright smoke job also runs against a live dev server. CI builds the bundle
+with `vite build` (not `npm run build`) so the Emscripten/WASM step is skipped on the runner —
+the physics-engine flag falls back to Rapier when the C++ bundle is absent. Enabling branch
+protection on `main` (require the CI `check` job) is recommended.
+
 ## Campaign Mode
 
 The recommended progression path is the alternating A/B campaign system (`EXTENDED_MAP` <-> `STATIONARY_TABLE`) driven by `AdventureTrackProgression` + `AdventureProgressionSupervisor`. See `docs/ADVENTURE_CAMPAIGN.md`.

--- a/tests/display-reels-telemetry.spec.ts
+++ b/tests/display-reels-telemetry.spec.ts
@@ -25,8 +25,6 @@ type MeasurementResult = {
   telemetry: ReelsTelemetry
 }
 
-const MIN_SPIN_FRAMES = 1
-
 async function bootGame(page: Page, renderer: 'webgl2' | 'webgpu'): Promise<void> {
   await page.goto(`http://localhost:5173/?renderer=${renderer}`)
   await page.evaluate(() => {


### PR DESCRIPTION
Blocking 'check' job: npm ci -> tsc -b -> lint -> vitest run -> vite build. Non-blocking Playwright smoke 'e2e' job against a live dev server. Uses vite build (not npm run build) to keep the Emscripten/WASM step off the runner.

Also fixes a pre-existing lint error that CI surfaced: dead MIN_SPIN_FRAMES const in display-reels-telemetry.spec.ts (orphaned in commit 440ce15), which would have made the first lint run red. Documents CI in README + AGENTS.md.


Claude-Session: https://claude.ai/code/session_017oGRDBnTnZatv9jVqpb14A